### PR TITLE
Ability to link a dashboard to a sitemap

### DIFF
--- a/web/app/app.js
+++ b/web/app/app.js
@@ -13,8 +13,9 @@
         'oc.lazyLoad',
         'angular-clipboard'
     ])
-    .config(['$routeProvider', 'localStorageServiceProvider', function($routeProvider, localStorageServiceProvider) {
+    .config(['$routeProvider', '$compileProvider', 'localStorageServiceProvider', function($routeProvider, $compileProvider, localStorageServiceProvider) {
         localStorageServiceProvider.setStorageType('localStorage');
+        $compileProvider.debugInfoEnabled(false);
 
         $routeProvider
             .when('/', {
@@ -24,6 +25,9 @@
                 resolve: {
                     dashboards: ['PersistenceService', function (persistenceService) {
                         return persistenceService.getDashboards();
+                    }],
+                    sitemaps: ['OHService', function (OHService) {
+                        return OHService.loadSitemaps();
                     }]
                 }
             })
@@ -35,6 +39,7 @@
                     dashboard: ['PersistenceService', '$route', function (persistenceService, $route) {
                         return persistenceService.getDashboard($route.current.params.id);
                     }],
+                    sitemappage: function () { return null; },
                     codemirror: ['$ocLazyLoad', function ($ocLazyLoad) {
                         return $ocLazyLoad.load([
                             'vendor/cm/lib/codemirror.css',
@@ -59,6 +64,58 @@
                 resolve: {
                     dashboard: ['PersistenceService', '$route', function (persistenceService, $route) {
                         return persistenceService.getDashboard($route.current.params.id);
+                    }],
+                    sitemappage: function () { return null; }
+                }
+            })
+            .when('/sitemap/view/:id/:page', {
+                templateUrl: 'app/dashboard/dashboard.view.html',
+                controller: 'DashboardViewCtrl',
+                controllerAs: 'vm',
+                resolve: {
+                    dashboard: ['PersistenceService', '$route', function (persistenceService, $route) {
+                        return persistenceService.getDashboard($route.current.params.id);
+                    }],
+                    sitemappage: ['PersistenceService', 'OHService', '$route', function (persistenceService, OHService, $route) {
+                        var dashboard = persistenceService.getDashboard($route.current.params.id);
+                        if (dashboard.id) return OHService.loadSitemapPage(dashboard.sitemap, $route.current.params.page);
+
+                        return dashboard.then(function (dashboard) {
+                            return OHService.loadSitemapPage(dashboard.sitemap, $route.current.params.page);
+                        });
+                    }]
+                }
+            })
+            .when('/sitemap/edit/:id/:page', {
+                templateUrl: 'app/dashboard/dashboard.edit.html',
+                controller: 'DashboardEditCtrl',
+                controllerAs: 'vm',
+                resolve: {
+                    dashboard: ['PersistenceService', '$route', function (persistenceService, $route) {
+                        return persistenceService.getDashboard($route.current.params.id);
+                    }],
+                    sitemappage: ['PersistenceService', 'OHService', '$route', function (persistenceService, OHService, $route) {
+                        var dashboard = persistenceService.getDashboard($route.current.params.id);
+                        if (dashboard.id) return OHService.loadSitemapPage(dashboard.sitemap, $route.current.params.page);
+
+                        return dashboard.then(function (dashboard) {
+                            return OHService.loadSitemapPage(dashboard.sitemap, $route.current.params.page);
+                        });
+                    }],
+                    codemirror: ['$ocLazyLoad', function ($ocLazyLoad) {
+                        return $ocLazyLoad.load([
+                            'vendor/cm/lib/codemirror.css',
+                            'vendor/cm/lib/codemirror.js'
+                        ]).then(function () {
+                            return $ocLazyLoad.load([
+                                'vendor/cm/addon/fold/xml-fold.js',
+                                'vendor/cm/addon/edit/matchbrackets.js',
+                                'vendor/cm/addon/edit/matchtags.js',
+                                'vendor/cm/addon/edit/closebrackets.js',
+                                'vendor/cm/addon/edit/closetag.js',
+                                'vendor/cm/mode/xml/xml.js'
+                            ]);
+                        });
                     }]
                 }
             })

--- a/web/app/dashboard/dashboard.edit.controller.js
+++ b/web/app/dashboard/dashboard.edit.controller.js
@@ -10,6 +10,7 @@ angular.module('app')
                 var pagelayout = $scope.dashboard.pagelayouts[$scope.page.id];
                 SitemapTranslationService.buildWidgetsFromSitemapPage($scope.widgets, $scope.page.widgets, pagelayout);
             } else {
+                if (!$scope.dashboard.widgets) $scope.dashboard.widgets = [];
                 $scope.widgets = $scope.dashboard.widgets;
                 $scope.widgetTypes = Widgets.getWidgetTypes();
             }
@@ -31,11 +32,11 @@ angular.module('app')
 
 
             $scope.clear = function() {
-                $scope.dashboard.widgets = [];
+                $scope.widgets = [];
             };
 
             $scope.addWidget = function(type) {
-                $scope.dashboard.widgets.push({
+                $scope.widgets.push({
                     name: "New Widget",
                     sizeX: 4,
                     sizeY: 4,

--- a/web/app/dashboard/dashboard.edit.html
+++ b/web/app/dashboard/dashboard.edit.html
@@ -1,5 +1,5 @@
 <div class="page-header controls">
-    <div uib-dropdown class="pull-right">
+    <div uib-dropdown class="pull-right" ng-if="!page">
         <button class="btn btn-default" uib-dropdown-toggle type="button" id="addWidgetMenu">
             <i class="glyphicon glyphicon-plus"></i> Add Widget
             <span class="caret"></span>
@@ -12,11 +12,12 @@
             </li>
         </ul>
     </div>
+    <a class="btn btn-danger pull-right" ng-click="resetPageLayout()"><i class="glyphicon glyphicon-floppy-remove"></i>&nbsp;Reset layout</a>
     <a class="btn" href="#/"><i class="glyphicon glyphicon-chevron-left"></i></a>
     <a class="btn btn-success" ng-click="save()"><i class="glyphicon glyphicon-save"></i>&nbsp;Save</a>
     <a class="btn btn-primary" ng-click="run()"><i class="glyphicon glyphicon-play"></i>&nbsp;Run</a>
 </div>
-<div ng-if="!dashboard.widgets.length">
+<div ng-if="!widgets.length && !page">
     <div class="pull-right">
         <h3>Add some widgets <i class="glyphicon glyphicon-arrow-up"></i></h3></div>
 </div>
@@ -26,7 +27,7 @@
 </div>
 <div gridster="gridsterOptions">
     <ul>
-        <li gridster-item="widget" ng-repeat="widget in dashboard.widgets">
+        <li gridster-item="widget" ng-repeat="widget in widgets">
             <div class="box box-design" ng-controller="CustomWidgetCtrl">
                 <div class="box-header pull-left" style="display: inline">
                     <i class="handle glyphicon glyphicon-move"></i>

--- a/web/app/dashboard/dashboard.edit.html
+++ b/web/app/dashboard/dashboard.edit.html
@@ -12,7 +12,7 @@
             </li>
         </ul>
     </div>
-    <a class="btn btn-danger pull-right" ng-click="resetPageLayout()"><i class="glyphicon glyphicon-floppy-remove"></i>&nbsp;Reset layout</a>
+    <a ng-if="page" class="btn btn-danger pull-right" ng-click="resetPageLayout()"><i class="glyphicon glyphicon-floppy-remove"></i>&nbsp;Reset layout</a>
     <a class="btn" href="#/"><i class="glyphicon glyphicon-chevron-left"></i></a>
     <a class="btn btn-success" ng-click="save()"><i class="glyphicon glyphicon-save"></i>&nbsp;Save</a>
     <a class="btn btn-primary" ng-click="run()"><i class="glyphicon glyphicon-play"></i>&nbsp;Run</a>

--- a/web/app/dashboard/dashboard.view.controller.js
+++ b/web/app/dashboard/dashboard.view.controller.js
@@ -1,11 +1,17 @@
-  angular
+angular
         .module('app')
         .controller('DashboardViewCtrl', DashboardViewController);
 
-  DashboardViewController.$inject = ['$scope', '$location', '$rootScope', '$timeout', 'dashboard', 'PersistenceService', 'OHService', 'Fullscreen'];
-  function DashboardViewController($scope, $location, $rootScope, $timeout, dashboard, PersistenceService, OHService, Fullscreen) {
+DashboardViewController.$inject = ['$scope', '$location', '$rootScope', '$timeout', 'dashboard', 'sitemappage', 'PersistenceService', 'OHService', 'SitemapTranslationService', 'Fullscreen'];
+function DashboardViewController($scope, $location, $rootScope, $timeout, dashboard, sitemappage, PersistenceService, OHService, SitemapTranslationService, Fullscreen) {
     var vm = this;
     vm.dashboard = dashboard;
+    if (sitemappage) {
+        vm.page = sitemappage.data;
+        vm.title = sitemappage.data.title;
+    } else {
+        vm.title = vm.dashboard.name;
+    }
 
     vm.gridsterOptions = {
         margins: [5, 5],
@@ -39,6 +45,18 @@
     ////////////////
 
     function activate() {
+        vm.widgets = [];
+        if (vm.dashboard.sitemap) {
+            var pagelayout = {};
+            if (vm.dashboard.pagelayouts && vm.dashboard.pagelayouts[vm.page.id])
+                pagelayout = vm.dashboard.pagelayouts[vm.page.id];
+
+            SitemapTranslationService.buildWidgetsFromSitemapPage(vm.widgets, vm.page.widgets, pagelayout);
+        } else {
+            vm.widgets = vm.dashboard.widgets;
+        }
+
+
         $timeout(function() {
             OHService.reloadItems();
         });
@@ -55,6 +73,14 @@
     };
 
     vm.toggleEdit = function() {
-        $location.url("/edit/" + dashboard.id);
+        if (vm.page) {
+            $location.url("/sitemap/edit/" + vm.dashboard.id + '/' + vm.page.id);
+        } else {
+            $location.url("/edit/" + vm.dashboard.id);
+        }
     };
-  }
+
+    vm.goToPage = function (pageid) {
+        $location.url('/sitemap/view/' + vm.dashboard.id + '/' + pageid);
+    };
+}

--- a/web/app/dashboard/dashboard.view.html
+++ b/web/app/dashboard/dashboard.view.html
@@ -11,7 +11,7 @@
     <a class="btn pull-right" ng-click="vm.refresh()" title="Refresh">
         <i class="glyphicon glyphicon-refresh"></i>
     </a>
-    <h2>&nbsp;{{vm.dashboard.name}} 
+    <h2>&nbsp;{{vm.title}} 
         <a class="btn btn-link btn-edit-dashboard"
             ng-if="!lockEditing"
             ng-click="vm.toggleEdit()"
@@ -22,9 +22,12 @@
 </div>
 <div ng-show="vm.ready" gridster="vm.gridsterOptions">
     <ul>
-        <li gridster-item="widget" ng-repeat="widget in vm.dashboard.widgets">
-            <div class="box">
+        <li gridster-item="widget" ng-repeat="widget in vm.widgets">
+            <div class="box" ng-if="!widget.ispagelink">
                 <generic-widget type="widget.type" ng-model="widget"></generic-widget>
+            </div>
+            <div class="box" ng-if="widget.ispagelink" ng-click="vm.goToPage(widget.pageid)">
+                <widget-button ng-model="widget"></widget-button>
             </div>
         </li>
     </ul>

--- a/web/app/menu/menu.controller.js
+++ b/web/app/menu/menu.controller.js
@@ -49,7 +49,6 @@
                 dashboards.push({ id: name, name: name, widgets: [] });
                 PersistenceService.saveDashboards();
             });
-
         }
 
         vm.toggleEditMode = function () {
@@ -100,10 +99,11 @@
         };
 
         vm.viewDashboard = function (dash) {
-            if (vm.editMode) {
-                $location.url('/edit/' + dash.id);
+            var action = vm.editMode ? "edit" : "view";
+            if (dash.sitemap) {
+                $location.url('/sitemap/' + action + '/' + dash.id + '/' + dash.sitemap);
             } else {
-                $location.url('/view/' + dash.id);
+                $location.url('/' + action + '/' + dash.id);
             }
         }
 
@@ -143,6 +143,7 @@
 
         $scope.form = {
             name: dashboard.name,
+            sitemap: dashboard.sitemap,
             sizeX: dashboard.sizeX,
             sizeY: dashboard.sizeY,
             col: dashboard.col,
@@ -173,6 +174,11 @@
         };
 
         $scope.submit = function() {
+            // Reset if sitemap link changed
+            if ($scope.form.sitemap !== dashboard.sitemap) {
+                dashboard.widgets = undefined;
+                dashboard.pagelayouts = undefined;
+            }
             angular.extend(dashboard, $scope.form);
             PersistenceService.getDashboard(dashboard.id).tile = angular.copy(dashboard.tile);
             PersistenceService.saveDashboards().then(function () {

--- a/web/app/menu/menu.html
+++ b/web/app/menu/menu.html
@@ -64,9 +64,9 @@
 <br />
 
 <!-- Tutorial part 2 -->
-<div ng-if="!vm.dashboards.length && vm.editMode" class="col-xs-12 text-muted">
+<div ng-if="!vm.dashboards.length && vm.editMode" class="col-xs-12">
     <div class="col-xs-4 text-center">
-        <div class="pull-left">
+        <div>
             <h4>
                 Click or tap here to create your first dashboard...
                 <br /><i class="glyphicon glyphicon-arrow-down"></i>

--- a/web/app/menu/menu.settings.tpl.html
+++ b/web/app/menu/menu.settings.tpl.html
@@ -5,6 +5,8 @@
             <h3>Dashboard Card Settings</h3>
         </div>
 
+        <div class="alert alert-warning" ng-if="sitemapchanged">WARNING: All current widgets and customizations will be lost if you change the sitemap link!</div>
+
         <div class="modal-body">
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Name</label>
@@ -12,12 +14,17 @@
                     <input name="name" type="text" ng-model="form.name" class="form-control" />
                 </div>
             </div>
-            <!--<div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
-                <div class="col-lg-9 col-md-9">
-                    <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+            <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
+                <label class="control-label col-lg-3 col-md-3">Link to sitemap</label>
+                <div class="col-lg-4 col-md-4">
+                    <select ng-model="form.sitemap" ng-change="sitemapchanged=true" ng-options="item.name as item.label for item in sitemaps" class="form-control">
+                        <option value=""></option>
+                    </select>
                 </div>
-            </div>-->
+                <div class="col-lg-5 col-md-5">
+                    <small ng-if="form.sitemap">If this tile is linked to a sitemap, you won't be able to add or remove widgets</small>
+                </div>
+            </div>
             <div class="form-group" ng-class="{error: _form.tile.background_image.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Background Image URL</label>
                 <div class="col-lg-9 col-md-9">

--- a/web/app/services/icon.service.js
+++ b/web/app/services/icon.service.js
@@ -57,7 +57,7 @@
             template: 
                 // TODO put this template in a HTML file
                 '<div class="btn-group" uib-dropdown is-open="status.isopen2">' +
-                '<a href id="iconset-picker-btn" class="btn btn-default" uib-dropdown-toggle>' +
+                '<a href id="iconset-picker-btn" class="btn btn-default" uib-dropdown-toggle disabled="{{disabled}}">' +
                 '{{setdropdownlabel}}&nbsp;<span class="caret" /></a>' +
                 '<ul class="dropdown-menu" role="menu" aria-labelledby="iconset-picker-btn">' +
                 '<li><a ng-click="clearIcon()"><i>(none)</i></a></li>' +
@@ -65,7 +65,7 @@
                 '</ul>' +
                 '</div><br />' +
                 '<div ng-if="iconset" class="btn-group" uib-dropdown is-open="status.isopen">' +
-                '<a href id="icon-picker-btn" class="btn btn-default" uib-dropdown-toggle>' +
+                '<a href id="icon-picker-btn" class="btn btn-default" uib-dropdown-toggle disabled="{{disabled}}">' +
                 '<img width="64px" height="64px" ng-src="{{iconUrl}}" />&nbsp;{{icon}}&nbsp;<span class="caret" />' +
                 '</a>' +
                 '<ul style="width: 420px" class="dropdown-menu" role="menu" aria-labelledby="icon-picker-btn">' +
@@ -75,7 +75,8 @@
                 '<br /><small ng-if="notice"><a target="_blank" href="{{noticeUrl}}">{{notice}}</a></small><br />',
             scope: {
                 iconset: '=',
-                icon: '='
+                icon: '=',
+                disabled: '='
             }
         };
         return directive;

--- a/web/app/services/openhab.service.js
+++ b/web/app/services/openhab.service.js
@@ -14,6 +14,8 @@
         this.onUpdate = onUpdate;
         this.sendCmd = sendCmd;
         this.reloadItems = reloadItems;
+        this.loadSitemaps = loadSitemaps;
+        this.loadSitemapPage = loadSitemapPage;
         //this.clearAllLongPollings = clearAllLongPollings;
 
         var liveUpdatesEnabled = false;
@@ -44,6 +46,21 @@
                 }
                 $rootScope.$emit('openhab-update');
             });
+        }
+
+        function loadSitemaps() {
+            $http.get('/rest/sitemaps')
+            .then(function (resp) {
+                console.log('Loaded sitemaps');
+
+                if (resp.data) {
+                    $rootScope.sitemaps = resp.data;
+                }
+            });
+        }
+
+        function loadSitemapPage(sitemap, page) {
+            return $http.get('/rest/sitemaps/' + sitemap + '/' + page);
         }
 
         function getItem(name) {

--- a/web/app/services/sitemap.service.js
+++ b/web/app/services/sitemap.service.js
@@ -1,0 +1,172 @@
+(function() {
+'use strict';
+
+    angular
+        .module('app.services')
+        .service('SitemapTranslationService', SitemapTranslationService);
+
+    SitemapTranslationService.$inject = ['OHService'];
+    function SitemapTranslationService(OHService) {
+        this.buildWidgetsFromSitemapPage = buildWidgets;
+        this.savePageLayoutToDashboard = savePageLayoutToDashboard; 
+
+        ////////////////
+
+        function buildWidgets(widgets, srcwidgets, pagelayout, cols, row, col) {
+            if (!cols) cols = 12;
+            if (!row) row = 0;
+            if (!col) col = 0;
+
+            angular.forEach(srcwidgets, function (widget) {
+                var w;
+                switch (widget.type) {
+                    case "Frame":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 12,
+                            sizeY: 1,
+                            type: 'label',
+                            name: widget.label,
+                            background: 'black'
+                        };
+                        break;
+                    case "Colorpicker":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'colorpicker',
+                            name: widget.label,
+                            item: (widget.item) ? widget.item.name : null
+                        };
+                        break;
+                    case "Slider":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'slider',
+                            name: widget.label,
+                            item: (widget.item) ? widget.item.name : null
+                        };
+                        break;
+                    case "Setpoint":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'knob',
+                            name: widget.label,
+                            item: (widget.item) ? widget.item.name : null
+                        };
+                        break;
+                    case "Switch":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'switch',
+                            name: widget.label,
+                            item: (widget.item) ? widget.item.name : null,
+                            iconset: (widget.icon) ? 'eclipse-smarthome-classic' : undefined,
+                            icon: (widget.icon) ? widget.icon : undefined,
+                        };
+                        break;
+                    case "Image":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'switch',
+                            name: widget.label,
+                            url: widget.url
+                        };
+                        break;
+                    case "Chart":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'chart',
+                            name: widget.label,
+                            item: (widget.item) ? widget.item.name : null,
+                            charttype: 'default'
+                        };
+                        break;
+                    default:
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'dummy',
+                            name: widget.label,
+                            iconset: (widget.icon) ? 'eclipse-smarthome-classic' : undefined,
+                            icon: (widget.icon) ? widget.icon : undefined,
+                            item: (widget.item) ? widget.item.name : '',
+                            background: 'transparent'
+                        };
+                        break;
+                }
+
+                if (col + w.sizeX > cols) {
+                    col = 0;
+                    row += widgets[widgets.length-1].sizeY;
+                }
+                w.row = row;
+                w.col = col;
+                col += w.sizeX;
+                if (col >= cols) {
+                    col = 0;
+                    row += w.sizeY;
+                }
+                console.log('positioning ' + w.name + ' at row=' + w.row + ", col=" + w.col);
+
+                if (widget.linkedPage) {
+                    w.ispagelink = true;
+                    w.pageid = widget.linkedPage.id;
+                    w.type = 'button';
+                    w.background = '#258'; //FIXME: use a variable
+                }
+
+                var layout = {};
+                if (widget.widgetId && pagelayout && pagelayout[widget.widgetId])
+                    layout = pagelayout[widget.widgetId];
+
+                angular.extend(w, layout);
+
+                widgets.push(w);
+
+                if (widget.widgets) {
+                    var pos = buildWidgets(widgets, widget.widgets, pagelayout, cols, row, col);
+                    row = pos.row;
+                    col = pos.col;
+                }
+
+            }); 
+
+            return { row: row, col: col};
+        }
+
+        function savePageLayoutToDashboard(widgets, page, dashboard) {
+            if (!dashboard.pagelayouts[page.id])
+                dashboard.pagelayouts[page.id] = {};
+
+            angular.forEach(widgets, function (widget) {
+                var layout = angular.copy(widget);
+                // strip settings coming from the sitemap
+                if (layout.name) delete layout.name;
+                if (layout.item) delete layout.item;
+                if (layout.icon) delete layout.icon;
+                if (layout.iconset) delete layout.iconset;
+                if (layout.floor) delete layout.floor;
+                if (layout.ceil) delete layout.ceil;
+                if (layout.step) delete layout.step;
+                if (layout.ispagelink) delete layout.ispagelink;
+                if (layout.pageid) delete layout.pageid;
+                if (layout.url) delete layout.url;
+
+                dashboard.pagelayouts[page.id][layout.id] = layout;
+            })
+        }
+    }
+})();

--- a/web/app/services/sitemap.service.js
+++ b/web/app/services/sitemap.service.js
@@ -77,9 +77,19 @@
                             id: widget.widgetId,
                             sizeX: 4,
                             sizeY: 4,
-                            type: 'switch',
+                            type: 'image',
                             name: widget.label,
                             url: widget.url
+                        };
+                        break;
+                    case "Webview":
+                        w = {
+                            id: widget.widgetId,
+                            sizeX: 4,
+                            sizeY: 4,
+                            type: 'frame',
+                            name: widget.label,
+                            frameUrl: widget.url
                         };
                         break;
                     case "Chart":

--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -5,6 +5,8 @@
             <h3>Button Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <div class="form-group">
                 <div class="col-xs-9"> 
@@ -14,19 +16,19 @@
                       <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                           <label class="control-label col-lg-3 col-md-3">Name</label>
                           <div class="col-lg-9 col-md-9">
-                              <input name="name" type="text" ng-model="form.name" class="form-control" />
+                              <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                           </div>
                       </div>
                       <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
                           <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
                           <div class="col-lg-9 col-md-9">
-                              <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+                              <select ng-disabled="page" ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
                           </div>
                       </div>
                       <div class="form-group" ng-class="{error: _form.command.$error && _form.submitted}">
                           <label class="control-label col-lg-3 col-md-3">Command value</label>
                           <div class="col-lg-9 col-md-9">
-                              <input name="command" type="text" ng-model="form.command" class="form-control" />
+                              <input ng-disabled="page" name="command" type="text" ng-model="form.command" class="form-control" />
                           </div>
                       </div>
                     </uib-tab>
@@ -111,7 +113,7 @@
                         <div class="form-group" ng-class="{error: _form.icon.$error && _form.submitted}">
                             <label class="control-label col-lg-3 col-md-3">Icon</label>
                             <div class="col-lg-9 col-md-9">
-                                <icon-picker iconset="form.iconset" icon="form.icon"></icon-picker>
+                                <icon-picker disabled="page" iconset="form.iconset" icon="form.icon"></icon-picker>
                                 <div class="col-xs-6 input-group" ng-if="form.icon">
                                     <div class="input-group-addon">Size</div>
                                     <input name="icon_size" ng-model="form.icon_size" class="form-control" />
@@ -194,7 +196,7 @@
         </div>
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -45,7 +45,9 @@
         vm.font_size = this.widget.font_size;
 
         function updateValue() {
-            vm.value = OHService.getItem(vm.widget.item).state;
+            var item = OHService.getItem(vm.widget.item);
+            if (!item) return;
+            vm.value = item.state;
             if (vm.value === vm.widget.command) {
                 vm.background = vm.widget.background_active;
                 vm.foreground = vm.widget.foreground_active;
@@ -60,6 +62,7 @@
         });
 
         vm.sendCommand = function () {
+            if (this.widget.ispagelink) return;
             OHService.sendCmd(this.widget.item, this.widget.command);
         }
 

--- a/web/app/widgets/chart/chart.settings.tpl.html
+++ b/web/app/widgets/chart/chart.settings.tpl.html
@@ -5,17 +5,19 @@
             <h3>Image Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Name</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                 </div>
             </div>
             <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
                 <div class="col-lg-9 col-md-9">
-                    <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+                    <select ng-disabled="page" ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
                 </div>
             </div>
             <div class="form-group" ng-class="{error: _form.charttype.$error && _form.submitted}">
@@ -31,13 +33,13 @@
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Service provider</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.service" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.service" class="form-control" />
                 </div>
             </div>
             <div class="form-group" ng-class="{error: _form.period.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Period</label>
                 <div class="col-lg-9 col-md-9">
-                    <select ng-model="form.period" class="form-control">
+                    <select ng-disabled="page" ng-model="form.period" class="form-control">
                         <option value="h">h</option>
                         <option value="4h">4h</option>
                         <option value="8h">8h</option>
@@ -62,7 +64,7 @@
         </div>
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/colorpicker/colorpicker.settings.tpl.html
+++ b/web/app/widgets/colorpicker/colorpicker.settings.tpl.html
@@ -5,23 +5,25 @@
             <h3>Color Picker Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Name</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                 </div>
             </div>
             <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
                 <div class="col-lg-9 col-md-9">
-                    <select ng-model="form.item" ng-options="item.name as item.name for item in items | filter:isColorItem" class="form-control"></select>
+                    <select ng-disabled="page" ng-model="form.item" ng-options="item.name as item.name for item in items | filter:isColorItem" class="form-control"></select>
                 </div>
             </div>
         </div>
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/dummy/dummy.settings.tpl.html
+++ b/web/app/widgets/dummy/dummy.settings.tpl.html
@@ -5,17 +5,19 @@
             <h3>Dummy Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Name</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                 </div>
             </div>
             <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
                 <div class="col-lg-9 col-md-9">
-                    <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+                    <select ng-disabled="page" ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
                 </div>
             </div>
 
@@ -69,7 +71,7 @@
             <div class="form-group" ng-class="{error: _form.icon.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Icon</label>
                 <div class="col-lg-9 col-md-9">
-                    <icon-picker iconset="form.iconset" icon="form.icon"></icon-picker>
+                    <icon-picker disabled="page" iconset="form.iconset" icon="form.icon"></icon-picker>
                     <div class="col-xs-5 input-group" ng-if="form.icon">
                         <div class="input-group-addon">Size</div>
                         <input name="icon_size" ng-model="form.icon_size" class="form-control" />
@@ -104,7 +106,7 @@
 
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/frame/frame.settings.tpl.html
+++ b/web/app/widgets/frame/frame.settings.tpl.html
@@ -5,6 +5,8 @@
             <h3>iFrame Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <uib-tabset>
                 <uib-tab heading="General">
@@ -14,13 +16,13 @@
                             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">Name</label>
                                 <div class="col-lg-9 col-md-9">
-                                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                                 </div>
                             </div>
                             <div class="form-group" ng-class="{error: _form.frameUrl.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">Url</label>
                                 <div class="col-lg-9 col-md-9">
-                                    <input type="url" name="frameUrl" ng-model="form.frameUrl" class="form-control">
+                                    <input ng-disabled="page" type="url" name="frameUrl" ng-model="form.frameUrl" class="form-control">
                                 </div>
                             </div>
                         </div>
@@ -63,7 +65,7 @@
         </div>
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/image/image.settings.tpl.html
+++ b/web/app/widgets/image/image.settings.tpl.html
@@ -5,11 +5,13 @@
             <h3>Image Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Name</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                 </div>
             </div>
             <!--<div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
@@ -21,7 +23,7 @@
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Image URL</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.url" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.url" class="form-control" />
                 </div>
             </div>
 
@@ -35,7 +37,7 @@
         </div>
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/knob/knob.settings.tpl.html
+++ b/web/app/widgets/knob/knob.settings.tpl.html
@@ -5,6 +5,8 @@
             <h3>Knob Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <uib-tabset>
                 <uib-tab heading="General">
@@ -15,13 +17,13 @@
                             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">Name</label>
                                 <div class="col-lg-9 col-md-9">
-                                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                                 </div>
                             </div>
                             <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
                                 <div class="col-lg-9 col-md-9">
-                                    <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+                                    <select ng-disabled="page" ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
                                 </div>
                             </div>
 
@@ -43,7 +45,7 @@
                                     <div class="form-group" ng-class="{error: _form.floor.$error && _form.submitted}">
                                         <label class="control-label col-xs-4">Min</label>
                                         <div class="col-xs-6">
-                                            <input name="min" type="number" ng-model="form.floor" class="form-control" />
+                                            <input ng-disabled="page" name="min" type="number" ng-model="form.floor" class="form-control" />
                                         </div>
                                     </div>
                                 </div>
@@ -51,7 +53,7 @@
                                     <div class="form-group" ng-class="{error: _form.ceil.$error && _form.submitted}">
                                         <label class="control-label col-xs-4">Max</label>
                                         <div class="col-xs-6">
-                                            <input name="max" type="number" ng-model="form.ceil" class="form-control" />
+                                            <input ng-disabled="page" name="max" type="number" ng-model="form.ceil" class="form-control" />
                                         </div>
                                     </div>
                                 </div>
@@ -59,7 +61,7 @@
                                     <div class="form-group" ng-class="{error: _form.step.$error && _form.submitted}">
                                         <label class="control-label col-xs-4">Step</label>
                                         <div class="col-xs-6">
-                                            <input name="step" type="number" step="any" ng-model="form.step" class="form-control" />
+                                            <input ng-disabled="page" name="step" type="number" step="any" ng-model="form.step" class="form-control" />
                                         </div>
                                     </div>
                                 </div>
@@ -406,7 +408,7 @@
 
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/label/label.settings.tpl.html
+++ b/web/app/widgets/label/label.settings.tpl.html
@@ -4,11 +4,14 @@
             <button type="button" class="close" ng-click="dismiss()" aria-hidden="true">&times;</button>
             <h3>Label Settings</h3>
         </div>
+
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Name</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                 </div>
             </div>
             <div class="form-group">
@@ -53,7 +56,7 @@
             </div>
         </div>
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/slider/slider.settings.tpl.html
+++ b/web/app/widgets/slider/slider.settings.tpl.html
@@ -5,6 +5,8 @@
             <h3>Slider Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <uib-tabset>
                 <uib-tab heading="General">
@@ -15,13 +17,13 @@
                             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">Name</label>
                                 <div class="col-lg-9 col-md-9">
-                                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                                 </div>
                             </div>
                             <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
                                 <div class="col-lg-9 col-md-9">
-                                    <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+                                    <select ng-disabled="page" ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
                                 </div>
                             </div>
                             <div class="form-group">
@@ -29,7 +31,7 @@
                                     <div class="form-group" ng-class="{error: _form.floor.$error && _form.submitted}">
                                         <label class="control-label col-xs-4">Min</label>
                                         <div class="col-xs-6">
-                                            <input name="min" type="number" ng-model="form.floor" class="form-control" />
+                                            <input ng-disabled="page" name="min" type="number" ng-model="form.floor" class="form-control" />
                                         </div>
                                     </div>
                                 </div>
@@ -37,7 +39,7 @@
                                     <div class="form-group" ng-class="{error: _form.ceil.$error && _form.submitted}">
                                         <label class="control-label col-xs-4">Max</label>
                                         <div class="col-xs-6">
-                                            <input name="max" type="number" ng-model="form.ceil" class="form-control" />
+                                            <input ng-disabled="page" name="max" type="number" ng-model="form.ceil" class="form-control" />
                                         </div>
                                     </div>
                                 </div>
@@ -45,7 +47,7 @@
                                     <div class="form-group" ng-class="{error: _form.step.$error && _form.submitted}">
                                         <label class="control-label col-xs-4">Step</label>
                                         <div class="col-xs-6">
-                                            <input name="step" type="number" step="any" ng-model="form.step" class="form-control" />
+                                            <input ng-disabled="page" name="step" type="number" step="any" ng-model="form.step" class="form-control" />
                                         </div>
                                     </div>
                                 </div>
@@ -184,7 +186,7 @@
 
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/app/widgets/switch/switch.settings.tpl.html
+++ b/web/app/widgets/switch/switch.settings.tpl.html
@@ -7,17 +7,19 @@
             <h3>Switch Settings</h3>
         </div>
 
+        <div ng-if="page" class="alert alert-warning">Some options are disabled because they are controlled by the sitemap definition.</div>
+
         <div class="modal-body">
             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">Name</label>
+                <label ng-disabled="page" class="control-label col-lg-3 col-md-3">Name</label>
                 <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                    <input ng-disabled="page" name="name" type="text" ng-model="form.name" class="form-control" />
                 </div>
             </div>
             <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
+                <label ng-disabled="page" class="control-label col-lg-3 col-md-3">OpenHAB Item</label>
                 <div class="col-lg-9 col-md-9">
-                    <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+                    <select ng-disabled="page" ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
                 </div>
             </div>
             
@@ -65,7 +67,7 @@
             <div class="form-group" ng-class="{error: _form.icon.$error && _form.submitted}">
                 <label class="control-label col-lg-3 col-md-3">Icon</label>
                 <div class="col-lg-9 col-md-9">
-                    <icon-picker iconset="form.iconset" icon="form.icon"></icon-picker>
+                    <icon-picker disabled="page" iconset="form.iconset" icon="form.icon"></icon-picker>
                     <div class="col-xs-5 input-group" ng-if="form.icon">
                         <div class="input-group-addon">Size</div>
                         <input name="icon_size" ng-model="form.icon_size" class="form-control" />
@@ -78,7 +80,7 @@
         </div>
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-if="!page" ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,7 @@
 		<script src="app/services/persistence.service.js"></script>
 		<script src="app/services/openhab.service.js"></script>
 		<script src="app/services/icon.service.js"></script>
+		<script src="app/services/sitemap.service.js"></script>
 
 		<script src="app/app.js"></script>
 		<script src="app/dashboard/dashboard.view.controller.js"></script>


### PR DESCRIPTION
This introduces a "link to sitemap" option for dashboards, accessible
in the dashboard tile settings. When linked to a sitemap, the dashboard
will act a standard sitemap explorer, with pages etc.

Widgets cannot be added or removed in this mode and the binding to
items cannot be changed, but they may be reordered and layout options
(colors, appearance settings...) may be changed.

NOTE:
When reordering the sitemap's widgets or adding new frames/pages,
unexpected things might happen - widgetIds are attributed sequen-
tially by the API and don't look too stable.

Other known bugs and limitations:
- Mappings for switches are not supported
- Selection, Webview, Mapview, Video are not supported
- Setpoints are rendered as knobs
- Conditional visibility or colors are not supported
- Formatting of labels are not supported

Signed-off-by: Yannick Schaus habpanel@schaus.net
