### PR TITLE
New settings: contextual dashboards, speech, misc

### DIFF
--- a/web/app/app.js
+++ b/web/app/app.js
@@ -32,8 +32,9 @@
                 controller: 'DashboardEditCtrl',
                 controllerAs: 'vm',
                 resolve: {
-                    dashboard: ['PersistenceService', '$route', function (persistenceService, $route) {
-                        return persistenceService.getDashboard($route.current.params.id);
+                    dashboard: ['PersistenceService', '$q', '$route', function (persistenceService, $q, $route) {
+                        var dashboard = persistenceService.getDashboard($route.current.params.id);
+                        return (dashboard) || $q.defer().reject("Unknown dashboard");
                     }],
                     codemirror: ['$ocLazyLoad', function ($ocLazyLoad) {
                         return $ocLazyLoad.load([
@@ -57,8 +58,9 @@
                 controller: 'DashboardViewCtrl',
                 controllerAs: 'vm',
                 resolve: {
-                    dashboard: ['PersistenceService', '$route', function (persistenceService, $route) {
-                        return persistenceService.getDashboard($route.current.params.id);
+                    dashboard: ['PersistenceService', '$q', '$route', function (persistenceService, $q, $route) {
+                        var dashboard = persistenceService.getDashboard($route.current.params.id);
+                        return (dashboard) || $q.defer().reject("Unknown dashboard");
                     }]
                 }
             })

--- a/web/app/dashboard/dashboard.view.controller.js
+++ b/web/app/dashboard/dashboard.view.controller.js
@@ -42,7 +42,7 @@
         $timeout(function() {
             OHService.reloadItems();
         });
-        iNoBounce.enable();
+        if ($rootScope.settings.no_scrolling) iNoBounce.enable(); else iNoBounce.disable();
       //Fullscreen.all();
     }
 

--- a/web/app/menu/menu.controller.js
+++ b/web/app/menu/menu.controller.js
@@ -6,8 +6,8 @@
         .controller('MenuCtrl', MenuController)
         .controller('DashboardSettingsCtrl', DashboardSettingsCtrl);
 
-    MenuController.$inject = ['$rootScope', '$scope', 'dashboards', '$interval', '$location', 'PersistenceService', 'prompt', '$filter', '$uibModal', 'Fullscreen'];
-    function MenuController($rootScope, $scope, dashboards, $interval, $location, PersistenceService, prompt, $filter, $modal, Fullscreen) {
+    MenuController.$inject = ['$rootScope', '$scope', 'dashboards', '$interval', '$location', 'PersistenceService', 'OHService', 'prompt', '$filter', '$uibModal', 'Fullscreen'];
+    function MenuController($rootScope, $scope, dashboards, $interval, $location, PersistenceService, OHService, prompt, $filter, $modal, Fullscreen) {
         var vm = this;
         vm.dashboards = dashboards;
         vm.editMode = false;
@@ -22,6 +22,8 @@
                 vm.clock = Date.now();
             }
             $interval(tick, 1000);
+            if ($rootScope.settings.no_scrolling) iNoBounce.enable(); else iNoBounce.disable();
+            OHService.reloadItems();
         }
 
         if (!$rootScope.menucolumns)
@@ -58,7 +60,7 @@
             if (vm.editMode)
                 iNoBounce.disable();
             else
-                iNoBounce.enable();
+                if ($rootScope.settings.no_scrolling) iNoBounce.enable();
         }
 
         vm.removeDashboard = function (dash) {

--- a/web/app/menu/menu.html
+++ b/web/app/menu/menu.html
@@ -8,7 +8,8 @@
         ng-hide="lockEditing" ng-click="vm.toggleEditMode()" ng-class="{ 'btn-danger': vm.editMode }">
         <i class="glyphicon glyphicon-cog"></i>
     </a>
-    <h1>{{vm.clock | date:'EEE d MMM HH:mm:ss'}}</h1>
+    <h1 ng-hide="settings.no_clock">{{vm.clock | date:'EEE d MMM HH:mm:ss'}}</h1>
+    <h1 ng-show="settings.no_clock">&nbsp;</h1>
 </div>
 <!-- Tutorial part 1 -->
 <div ng-if="!vm.dashboards.length">

--- a/web/app/services/openhab.service.js
+++ b/web/app/services/openhab.service.js
@@ -7,8 +7,8 @@
         .value('OH2ServiceConfiguration', {})
         .service('OH2StorageService', OH2StorageService);
 
-    OHService.$inject = ['$rootScope', '$http', '$q', '$timeout', '$interval', '$filter', 'atmosphereService'];
-    function OHService($rootScope, $http, $q, $timeout, $interval, $filter, atmosphereService) {
+    OHService.$inject = ['$rootScope', '$http', '$q', '$timeout', '$interval', '$filter', '$location', 'atmosphereService', 'SpeechService'];
+    function OHService($rootScope, $http, $q, $timeout, $interval, $filter, $location, atmosphereService, SpeechService) {
         this.getItem = getItem;
         this.getItems = getItems;
         this.onUpdate = onUpdate;
@@ -95,6 +95,16 @@
                                     console.log("Updating " + item.name + " state from " + item.state + " to " + payload.value);
                                     item.state = payload.value;
                                     $rootScope.$emit('openhab-update');
+
+                                    if (item.state && $rootScope.settings.speech_synthesis_item === item.name) {
+                                        console.log('Speech synthesis item state changed! Speaking it now.');
+                                        SpeechService.speak($rootScope.settings.speech_synthesis_voice, item.state);
+                                    }
+                                    if (item.state && $rootScope.settings.dashboard_control_item === item.name) {
+                                        console.log('Dashboard control item state changed, attempting navigation to: ' + item.state);
+                                        $location.url('/view/' + item.state);
+                                    }
+
                                 });
                             }
                         }
@@ -143,6 +153,16 @@
                                 console.log("Received push message: Changing " + item.name + " state from " + item.state + " to " + data.state);
                                 item.state = data.state;
                                 $rootScope.$emit('openhab-update');
+
+                                if (item.state && $rootScope.settings.speech_synthesis_item === item.name) {
+                                    console.log('Speech synthesis item state changed! Speaking it now.');
+                                    SpeechService.speak($rootScope.settings.speech_synthesis_voice, item.state);
+                                }
+                                if (item.state && $rootScope.settings.dashboard_control_item === item.name) {
+                                    console.log('Dashboard control item state changed, attempting navigation to: ' + item.state);
+                                    $location.url('/view/' + item.state);
+                                }
+                                
                             });
                         }
                     }

--- a/web/app/services/speech.service.js
+++ b/web/app/services/speech.service.js
@@ -1,0 +1,41 @@
+(function() {
+'use strict';
+
+    angular
+        .module('app.services')
+        .service('SpeechService', SpeechService);
+
+    SpeechService.$inject = ['$window', '$q', '$filter'];
+    function SpeechService($window, $q, $filter) {
+        this.getVoices = getVoices;
+        this.speak = speak;
+        
+        ////////////////
+
+        function getVoices() {
+            if (!('SpeechSynthesisUtterance' in window))
+                return [];
+
+            return speechSynthesis.getVoices();
+        }
+
+
+        function speak(voicename, text) {
+            if (!('SpeechSynthesisUtterance' in window)) {
+                console.log('No support for speech synthesis on this platform!');
+                return;
+            }
+
+            if (!speechSynthesis.getVoices()) {
+                console.log("No voices?");
+            }
+
+            var utterance = new SpeechSynthesisUtterance(text);
+            var voice = $filter('filter')(speechSynthesis.getVoices(), {name: voicename})[0];
+            utterance.voice = voice;
+            if (voice.lang) utterance.lang = voice.lang;
+
+            speechSynthesis.speak(utterance);
+        }
+    }
+})();

--- a/web/app/settings/settings.html
+++ b/web/app/settings/settings.html
@@ -39,16 +39,54 @@
 
 <div class="box col-md-5">
     <br />
-    <h4>Miscellaneous Settings</h4>
+    <h4>Appearance</h4>
 
-    <h5>Theme</h5>
+    <label>Theme</label>
     <select class="form-control" ng-change="vm.saveOptions()" ng-model="settings.theme" ng-options="theme.id as theme.name for theme in vm.themes"></select>
     <br />
     <br />
-    <h5>Background image</h5>
+    <label>Background image</label>
     <input type="text" class="form-control" ng-blur="vm.saveOptions()" ng-model="vm.background_image" placeholder="Example: //source.unsplash.com/random" />
     <br />
     <br />
+    <div class="input-group">
+        <input type="checkbox" ng-model="settings.no_clock" ng-change="vm.saveOptions()" id="no_clock" /><label for="no_clock">&nbsp;No clock on the home menu</label>
+    </div>
+    <div class="input-group">
+        <input type="checkbox" ng-model="settings.no_scrolling" ng-change="vm.saveOptions()" id="no_scrolling" /><label for="no_scrolling">&nbsp;Prevent scrolling (when not editing)</label>
+    </div>
+
+
+    <br />
+    <br /> 
+    <h4>Spoken Feedback</h4>
+    <label>Voice</label>
+    <div class="form-group">
+
+    <select class="form-control" ng-change="vm.saveOptions()" ng-model="settings.speech_synthesis_voice" ng-options="voice.name as voice.name + (voice.lang ? ' ('+voice.lang+')' : '') for voice in vm.voices">
+        <option value=""></option>
+    </select>
+    <small>Available voices depend on the operating system and browser environments.</small>
+    <br />
+    <button class="btn btn-primary" ng-click="vm.speakTestSentence()">Test</button>
+
+    <br />
+    <br />
+    <label>Speak the new value of the following item when it changes:</label>
+    <select ng-model="settings.speech_synthesis_item" ng-change="vm.saveOptions()" ng-options="item.name as item.name for item in items | filter: vm.isStringItem" class="form-control">
+        <option value=""></option>
+    </select>
+    <br />
+    <br />
+
+
+    <h4>Switch dashboard with item value</h4>    
+    <label>When this item changes to a dashboard's name, switch to it:</label>
+    <div class="form-group">
+        
+    <select ng-model="settings.dashboard_control_item" ng-change="vm.saveOptions()" ng-options="item.name as item.name for item in items | filter: vm.isStringItem" class="form-control">
+        <option value=""></option>
+    </select>
 </div>
 
 <br />

--- a/web/index.html
+++ b/web/index.html
@@ -22,8 +22,7 @@
 				console.log('Service worker registered');
 			})
 			.catch(function(what) {
-				console.error('Service worker not registered: ' + what);
-				console.error(whut);
+				console.info('Service worker not registered (not using HTTPS?): ' + what);
 			});
 		});
 		</script>
@@ -48,6 +47,7 @@
 		<script src="app/services/persistence.service.js"></script>
 		<script src="app/services/openhab.service.js"></script>
 		<script src="app/services/icon.service.js"></script>
+		<script src="app/services/speech.service.js"></script>
 
 		<script src="app/app.js"></script>
 		<script src="app/dashboard/dashboard.view.controller.js"></script>


### PR DESCRIPTION
- Text-to-speech feature: have the device speak the new
  value of a String item when it changes
  (depends on device, OS, browser capabilities)
- Server-enabled dashboard switching: have an item's state update trigger
  a switch to another dashboard (great with server-side rules)
- Add option to prevent scrolling on tablets (now disabled by default)
- Add option to hide the clock in the main menu

Signed-off-by: Yannick Schaus <habpanel@schaus.net>