### PR TITLE
Kiosk mode

### DIFF
--- a/web/app/dashboard/dashboard.view.controller.js
+++ b/web/app/dashboard/dashboard.view.controller.js
@@ -2,8 +2,8 @@
         .module('app')
         .controller('DashboardViewCtrl', DashboardViewController);
 
-  DashboardViewController.$inject = ['$scope', '$location', '$rootScope', '$timeout', 'dashboard', 'PersistenceService', 'OHService', 'Fullscreen'];
-  function DashboardViewController($scope, $location, $rootScope, $timeout, dashboard, PersistenceService, OHService, Fullscreen) {
+  DashboardViewController.$inject = ['$scope', '$location', '$rootScope', '$routeParams', '$timeout', 'dashboard', 'PersistenceService', 'OHService', 'Fullscreen'];
+  function DashboardViewController($scope, $location, $rootScope, $routeParams, $timeout, dashboard, PersistenceService, OHService, Fullscreen) {
     var vm = this;
     vm.dashboard = dashboard;
 
@@ -43,7 +43,7 @@
             OHService.reloadItems();
         });
         if ($rootScope.settings.no_scrolling) iNoBounce.enable(); else iNoBounce.disable();
-      //Fullscreen.all();
+        $rootScope.kioskMode = ($routeParams.kiosk == 'on');
     }
 
     vm.refresh = function() {

--- a/web/app/dashboard/dashboard.view.html
+++ b/web/app/dashboard/dashboard.view.html
@@ -1,4 +1,4 @@
-<div class="header">
+<div class="header" ng-if="!kioskMode">
     <a class="btn pull-left" onclick="window.history.back()" title="Go back">
         <i class="glyphicon glyphicon-chevron-left"></i>
     </a>

--- a/web/app/menu/menu.controller.js
+++ b/web/app/menu/menu.controller.js
@@ -6,8 +6,8 @@
         .controller('MenuCtrl', MenuController)
         .controller('DashboardSettingsCtrl', DashboardSettingsCtrl);
 
-    MenuController.$inject = ['$rootScope', '$scope', 'dashboards', '$interval', '$location', 'PersistenceService', 'OHService', 'prompt', '$filter', '$uibModal', 'Fullscreen'];
-    function MenuController($rootScope, $scope, dashboards, $interval, $location, PersistenceService, OHService, prompt, $filter, $modal, Fullscreen) {
+    MenuController.$inject = ['$rootScope', '$scope', 'dashboards', '$routeParams', '$interval', '$location', 'PersistenceService', 'OHService', 'prompt', '$filter', '$uibModal', 'Fullscreen'];
+    function MenuController($rootScope, $scope, dashboards, $routeParams, $interval, $location, PersistenceService, OHService, prompt, $filter, $modal, Fullscreen) {
         var vm = this;
         vm.dashboards = dashboards;
         vm.editMode = false;
@@ -23,6 +23,8 @@
             }
             $interval(tick, 1000);
             if ($rootScope.settings.no_scrolling) iNoBounce.enable(); else iNoBounce.disable();
+            $rootScope.kioskMode = ($routeParams.kiosk == 'on');
+
             OHService.reloadItems();
         }
 

--- a/web/app/menu/menu.html
+++ b/web/app/menu/menu.html
@@ -1,4 +1,4 @@
-<div class="header">
+<div class="header" ng-hide="kioskMode">
     <a class="btn btn-link pull-right" title="Toggle full screen"
         ng-click="vm.goFullscreen()">
         <i class="glyphicon glyphicon-resize-full"></i>

--- a/web/index.html
+++ b/web/index.html
@@ -62,7 +62,7 @@
 </head>
 
 <body>
-    <div class="container" ng-view></div>
+    <div class="container" ng-view ng-style="{ 'padding-top': kioskMode ? 0 : 'auto' }"></div>
 </body>
 
 </html>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -33,7 +33,6 @@
       "type": "image/png"
     }
   ],
-  "start_url": "./index.html",
   "display": "fullscreen",
   "background_color": "black"
 }


### PR DESCRIPTION
Add ?kiosk=on to the URL to hide the header in dashboards and the main menu (useful for scenarios where limited navigation is desired).

Amended the web app manifest so adding to home from Chrome goes back to the last dashboard.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>