### PR TITLE
Fix OH2 service custom widgets initialization bug

### DIFF
--- a/web/app/services/openhab.service.js
+++ b/web/app/services/openhab.service.js
@@ -322,7 +322,7 @@
                 if ($rootScope.panelsRegistry[currentPanelConfig].customwidgets)
                     $rootScope.customwidgets = $rootScope.panelsRegistry[currentPanelConfig].customwidgets;
                 else
-                    $rootScope.settings = {};
+                    $rootScope.customwidgets = {};
             }
         }
 


### PR DESCRIPTION
Fixes an initialization bug with the custom widget collection when using the OH2 service

Signed-off-by: Yannick Schaus <habpanel@schaus.net>