### PR TITLE
Initial panel configuration service parameter

### DIFF
--- a/ESH-INF/config/config.xml
+++ b/ESH-INF/config/config.xml
@@ -16,6 +16,11 @@
             <label>Lock editing</label>
             <description>Edit mode is unavailable in the UI when enabled. Keeping the configuration locked and unlocking only when needed helps prevent accidental changes.</description>
         </parameter>
+        <parameter name="initialPanelConfig" type="text" required="false">
+            <default></default>
+            <label>Initial panel configuration</label>
+            <description>The name of the existing panel configuration to switch to initially when accessing HABPanel with no prior local configuration.</description>
+        </parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/web/app/app.js
+++ b/web/app/app.js
@@ -38,8 +38,9 @@
                 controllerAs: 'vm',
                 resolve: {
                     dashboard: ['PersistenceService', '$q', '$route', function (persistenceService, $q, $route) {
-                        var dashboard = persistenceService.getDashboard($route.current.params.id);
-                        return (dashboard) || $q.defer().reject("Unknown dashboard");
+                        var dashboard = persistenceService.getDashboard($route.current.params.id, true);
+                        if (persistenceService.isEditingLocked()) return $q.reject("Editing is locked");
+                        return (dashboard) || $q.reject("Unknown dashboard");
                     }],
                     codemirror: ['$ocLazyLoad', function ($ocLazyLoad) {
                         return $ocLazyLoad.load([
@@ -66,7 +67,7 @@
                 resolve: {
                     dashboard: ['PersistenceService', '$q', '$route', function (persistenceService, $q, $route) {
                         var dashboard = persistenceService.getDashboard($route.current.params.id);
-                        return (dashboard) || $q.defer().reject("Unknown dashboard");
+                        return (dashboard) || $q.reject("Unknown dashboard");
                     }]
                 }
             })
@@ -75,8 +76,10 @@
                 controller: 'SettingsCtrl',
                 controllerAs: 'vm',
                 resolve: {
-                    dashboards: ['PersistenceService', function (persistenceService) {
-                        return persistenceService.getDashboards();
+                    dashboards: ['PersistenceService', '$q', function (persistenceService, $q) {
+                        var dashboards = persistenceService.getDashboards(true);
+                        if (persistenceService.isEditingLocked()) return $q.reject("Editing is locked");
+                        return dashboards;
                     }],
                     themes: ['$http', function ($http) {
                         return $http.get('assets/styles/themes/themes.json');
@@ -88,8 +91,10 @@
                 controller: 'SettingsLocalConfigCtrl',
                 controllerAs: 'vm',
                 resolve: {
-                    dashboards: ['PersistenceService', function (persistenceService) {
-                        return persistenceService.getDashboards();
+                    dashboards: ['PersistenceService', '$q', function (persistenceService, $q) {
+                        var dashboards = persistenceService.getDashboards(true);
+                        if (persistenceService.isEditingLocked()) return $q.reject("Editing is locked");
+                        return dashboards;
                     }],
                     codemirror: ['$ocLazyLoad', '$timeout', function ($ocLazyLoad, $timeout) {
                         return $ocLazyLoad.load([
@@ -111,8 +116,10 @@
                 controller: 'WidgetListCtrl',
                 controllerAs: 'vm',
                 resolve: {
-                    widgets: ['PersistenceService', function (persistenceService) {
-                        return persistenceService.getCustomWidgets();
+                    widgets: ['PersistenceService', '$q', function (persistenceService, $q) {
+                        var widgets = persistenceService.getCustomWidgets();
+                        if (persistenceService.isEditingLocked()) return $q.reject("Editing is locked");
+                        return widgets;
                     }]
                 }
             })
@@ -121,8 +128,10 @@
                 controller: 'WidgetDesignerCtrl',
                 controllerAs: 'vm',
                 resolve: {
-                    widget: ['PersistenceService', '$route', function (persistenceService, $route) {
-                        return persistenceService.getCustomWidget($route.current.params.id);
+                    widget: ['PersistenceService', '$route', '$q', function (persistenceService, $route, $q) {
+                        var widget = persistenceService.getCustomWidget($route.current.params.id);
+                        if (persistenceService.isEditingLocked()) return $q.reject("Editing is locked");
+                        return widget;
                     }],
                     codemirror: ['$ocLazyLoad', '$timeout', function ($ocLazyLoad, $timeout) {
                         return $ocLazyLoad.load([

--- a/web/app/services/openhab.service.js
+++ b/web/app/services/openhab.service.js
@@ -328,6 +328,15 @@
         function getCurrentPanelConfig() {
             if (!$rootScope.currentPanelConfig) {
                 $rootScope.currentPanelConfig = localStorageService.get("currentPanelConfig");
+
+                if (!$rootScope.currentPanelConfig) {
+                    // if it's still not set and we have an initial panel config, switch to it
+                    var initialPanelConfig = OH2ServiceConfiguration.initialPanelConfig;
+                    if (initialPanelConfig && $rootScope.panelsRegistry[initialPanelConfig]) {
+                        $rootScope.currentPanelConfig = initialPanelConfig;
+                        localStorageService.set("currentPanelConfig", initialPanelConfig);
+                    }
+                }
             }
 
             return $rootScope.currentPanelConfig;


### PR DESCRIPTION
- New parameter "initialPanelConfig" in the openHAB 2 service
  configuration - will be taken into account only if a configuration
  with this name exists and none is set yet.
- Reject access to routes when lockEditing is enabled.

Related to #78.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>