### PR TITLE
Additional button widget action types

### DIFF
--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -9,7 +9,7 @@
             <div class="form-group">
                 <div class="col-xs-9"> 
                 <uib-tabset>
-                    <uib-tab heading="Binding">
+                    <uib-tab heading="General">
                       <br />
                       <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                           <label class="control-label col-lg-3 col-md-3">Name</label>
@@ -17,20 +17,41 @@
                               <input name="name" type="text" ng-model="form.name" class="form-control" />
                           </div>
                       </div>
-                      <div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
+                      <div class="form-group" ng-class="{error: _form.action_type.$error && _form.submitted}">
+                          <label class="col-lg-3 col-md-3">Action type</label>
+                          <div class="col-lg-9 col-md-9">
+                              <select ng-model="form.action_type" class="form-control">
+                                  <option value="command">Send a fixed command to an item</option>
+                                  <option value="toggle">Alternate item between 2 states</option>
+                                  <option value="navigate">Navigate to another dashboard</option>
+                              </select>
+                          </div>
+                      </div>
+                      <div ng-if="form.action_type !== 'navigate'" class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
                           <label class="control-label col-lg-3 col-md-3">openHAB Item</label>
                           <div class="col-lg-9 col-md-9">
                                 <item-picker ng-model="form.item"></item-picker>
                           </div>
                       </div>
-                      <div class="form-group" ng-class="{error: _form.command.$error && _form.submitted}">
+                      <div ng-if="form.action_type !== 'navigate'" class="form-group" ng-class="{error: _form.command.$error && _form.submitted}">
                           <label class="control-label col-lg-3 col-md-3">Command value</label>
                           <div class="col-lg-9 col-md-9">
                               <input name="command" type="text" ng-model="form.command" class="form-control" />
                           </div>
                       </div>
+                      <div ng-if="form.action_type === 'toggle'" class="form-group" ng-class="{error: _form.command_alt.$error && _form.submitted}">
+                          <label class="control-label col-lg-3 col-md-3">Alternate command value</label>
+                          <div class="col-lg-9 col-md-9">
+                              <input name="command" type="text" ng-model="form.command_alt" class="form-control" />
+                          </div>
+                      </div>
+                      <div ng-if="form.action_type === 'navigate'" class="form-group" ng-class="{error: _form.navigate_dashboard.$error && _form.submitted}">
+                          <label class="control-label col-lg-3 col-md-3">Dashboard</label>
+                          <div class="col-lg-9 col-md-9">
+                              <select ng-model="form.navigate_dashboard" class="form-control" ng-options="dashboard.id as dashboard.name for dashboard in dashboards"></select>
+                          </div>
+                      </div>
                     </uib-tab>
-
 
                     <uib-tab heading="Inactive">
                     <br />

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -35,8 +35,8 @@
         function link(scope, element, attrs) {
         }
     }
-    ButtonController.$inject = ['$rootScope', '$scope', 'OHService'];
-    function ButtonController ($rootScope, $scope, OHService) {
+    ButtonController.$inject = ['$rootScope', '$scope', '$location', 'OHService'];
+    function ButtonController ($rootScope, $scope, $location, OHService) {
         var vm = this;
         this.widget = this.ngModel;
         
@@ -60,7 +60,25 @@
         });
 
         vm.sendCommand = function () {
-            OHService.sendCmd(this.widget.item, this.widget.command);
+            switch (vm.widget.action_type) {
+                case "navigate":
+                    if (vm.widget.navigate_dashboard) {
+                        $location.url('/view/' + vm.widget.navigate_dashboard);
+                    }
+                    break;
+                case "toggle":
+                    if (vm.widget.command && vm.widget.command_alt) {
+                        if (vm.value === vm.widget.command) {
+                            OHService.sendCmd(this.widget.item, this.widget.command_alt);
+                        } else {
+                            OHService.sendCmd(this.widget.item, this.widget.command);
+                        }
+                    }
+                    break;
+                default:
+                    OHService.sendCmd(this.widget.item, this.widget.command);
+                    break;
+            }
         }
 
     }
@@ -80,7 +98,10 @@
             col: widget.col,
             row: widget.row,
             item: widget.item,
+            action_type: widget.action_type || 'command',
             command: widget.command,
+            command_alt: widget.command_alt,
+            navigate_dashboard: widget.navigate_dashboard,
             background: widget.background,
             foreground: widget.foreground,
             font_size: widget.font_size,
@@ -107,6 +128,21 @@
 
         $scope.submit = function() {
             angular.extend(widget, $scope.form);
+            switch (widget.action_type) {
+                case "navigate":
+                    delete widget.item;
+                    delete widget.command;
+                    delete widget.command_alt;
+                    break;
+                case "toggle":
+                    delete widget.navigate_dashboard;
+                    break;
+                default:
+                    delete widget.command_alt;
+                    delete widget.navigate_dashboard;
+                    delete widget.action_type;
+                    break;
+            }
 
             $modalInstance.close(widget);
         };

--- a/web/app/widgets/widgets.module.js
+++ b/web/app/widgets/widgets.module.js
@@ -136,7 +136,8 @@
         }
 
         $scope.$watch("vm.selectedItem", function (newitem, oldvalue) {
-            $scope.vm.ngModel = newitem.name;
+            if (newitem && newitem.name)
+                $scope.vm.ngModel = newitem.name;
         });
         
     }


### PR DESCRIPTION
The button widget can now perform the following actions, beside
sending a fixed command to an item:
- toggle the state of an item between 2 values (if the state is
  already equal to the primary command, use the alternate);
- navigate to another dashboard.

Closes #22.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>