### PR TITLE
Experimental dashboard options

### DIFF
--- a/web/app/dashboard/dashboard.edit.controller.js
+++ b/web/app/dashboard/dashboard.edit.controller.js
@@ -5,8 +5,9 @@ angular.module('app')
             $scope.dashboard = dashboard;
 
             $scope.gridsterOptions = {
-                margins: [5, 5],
-                columns: 12,
+                margins: $scope.dashboard.widget_margin ?
+                            [$scope.dashboard.widget_margin, $scope.dashboard.widget_margin] : [5, 5],
+                columns: $scope.dashboard.columns || 12,
                 pushing: false,
                 floating: false,
                 mobileModeEnabled: false,

--- a/web/app/dashboard/dashboard.view.controller.js
+++ b/web/app/dashboard/dashboard.view.controller.js
@@ -8,8 +8,9 @@
     vm.dashboard = dashboard;
 
     vm.gridsterOptions = {
-        margins: [5, 5],
-        columns: 12,
+        margins: (vm.dashboard.widget_margin) ?
+                    [vm.dashboard.widget_margin, vm.dashboard.widget_margin] : [5, 5],
+        columns: vm.dashboard.columns || 12,
         pushing: false,
         floating: false,
         mobileModeEnabled: false,

--- a/web/app/menu/menu.controller.js
+++ b/web/app/menu/menu.controller.js
@@ -151,7 +151,8 @@
             sizeY: dashboard.sizeY,
             col: dashboard.col,
             row: dashboard.row,
-            //item: dashboard.item,
+            columns: dashboard.columns,
+            widget_margin: dashboard.widget_margin,
             tile: {
                 background_image: dashboard.tile.background_image,
                 backdrop_iconset: dashboard.tile.backdrop_iconset,

--- a/web/app/menu/menu.settings.tpl.html
+++ b/web/app/menu/menu.settings.tpl.html
@@ -2,70 +2,91 @@
     <form name="_form" class="form-horizontal" ng-submit="submit(_form)">
         <div class="modal-header">
             <button type="button" class="close" ng-click="dismiss()" aria-hidden="true">&times;</button>
-            <h3>Dashboard Card Settings</h3>
+            <h3>Dashboard Settings</h3>
         </div>
 
         <div class="modal-body">
-            <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">Name</label>
-                <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.name" class="form-control" />
-                </div>
-            </div>
-            <!--<div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">openHAB Item</label>
-                <div class="col-lg-9 col-md-9">
-                    <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
-                </div>
-            </div>-->
-            <div class="form-group" ng-class="{error: _form.tile.background_image.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">Background Image URL</label>
-                <div class="col-lg-9 col-md-9">
-                    <input name="name" type="text" ng-model="form.tile.background_image" class="form-control" />
-                </div>
-            </div>
-
-            <div class="form-group" ng-class="{error: _form.tile.backdrop_icon.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">Backdrop Icon</label>
-                <div class="col-lg-9 col-md-9">
-                    <icon-picker iconset="form.tile.backdrop_iconset" icon="form.tile.backdrop_icon"></icon-picker>
-                    <div ng-if="form.tile.backdrop_icon" class="checkbox">
-                        <label>
-                            <input type="checkbox" name="vertical" ng-model="form.tile.backdrop_center" /> Center backdrop horizontally
-                        </label>
+            <uib-tabset>
+                <uib-tab heading="Menu tile">
+                    <br />
+                    <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Name</label>
+                        <div class="col-lg-9 col-md-9">
+                            <input name="name" type="text" ng-model="form.name" class="form-control" />
+                        </div>
                     </div>
-                </div>
-            </div>
-
-            <div class="form-group" ng-class="{error: _form.icon.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">Icon</label>
-                <div class="col-lg-9 col-md-9">
-                    <icon-picker iconset="form.tile.iconset" icon="form.tile.icon"></icon-picker>
-                    <div class="col-xs-5 input-group" ng-if="form.tile.icon">
-                        <div class="input-group-addon">Size</div>
-                        <input name="icon_size" ng-model="form.tile.icon_size" class="form-control" />
-                        <div class="input-group-addon">px</div>
+                    <!--<div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">openHAB Item</label>
+                        <div class="col-lg-9 col-md-9">
+                            <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
+                        </div>
+                    </div>-->
+                    <div class="form-group" ng-class="{error: _form.tile.background_image.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Background Image URL</label>
+                        <div class="col-lg-9 col-md-9">
+                            <input name="name" type="text" ng-model="form.tile.background_image" class="form-control" />
+                        </div>
                     </div>
-                    <div ng-if="form.icon" class="checkbox">
-                        <label>
-                            <input type="checkbox" name="vertical" ng-model="form.tile.icon_nolinebreak" /> Icon left of label instead of below
-                        </label>
-                    </div>
-                    <div ng-if="form.icon" class="checkbox">
-                        <label>
-                            <input type="checkbox" name="vertical" ng-model="form.tile.icon_replacestext" /> Icon replaces textual value display
-                        </label>
-                    </div>
-                </div>
-            </div>
 
-            <div class="form-group" ng-class="{error: _form.tile.title_color.$error && _form.submitted}">
-                <label class="control-label col-lg-3 col-md-3">Title Text color</label>
-                <div class="col-lg-4 col-md-4">
-                    <div dab-model="form.tile.title_color" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
-                </div>
-            </div>
+                    <div class="form-group" ng-class="{error: _form.tile.backdrop_icon.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Backdrop Icon</label>
+                        <div class="col-lg-9 col-md-9">
+                            <icon-picker iconset="form.tile.backdrop_iconset" icon="form.tile.backdrop_icon"></icon-picker>
+                            <div ng-if="form.tile.backdrop_icon" class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="vertical" ng-model="form.tile.backdrop_center" /> Center backdrop horizontally
+                                </label>
+                            </div>
+                        </div>
+                    </div>
 
+                    <div class="form-group" ng-class="{error: _form.icon.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Icon</label>
+                        <div class="col-lg-9 col-md-9">
+                            <icon-picker iconset="form.tile.iconset" icon="form.tile.icon"></icon-picker>
+                            <div class="col-xs-5 input-group" ng-if="form.tile.icon">
+                                <div class="input-group-addon">Size</div>
+                                <input name="icon_size" ng-model="form.tile.icon_size" class="form-control" />
+                                <div class="input-group-addon">px</div>
+                            </div>
+                            <div ng-if="form.icon" class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="vertical" ng-model="form.tile.icon_nolinebreak" /> Icon left of label instead of below
+                                </label>
+                            </div>
+                            <div ng-if="form.icon" class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="vertical" ng-model="form.tile.icon_replacestext" /> Icon replaces textual value display
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group" ng-class="{error: _form.tile.title_color.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Title Text color</label>
+                        <div class="col-lg-4 col-md-4">
+                            <div dab-model="form.tile.title_color" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
+                        </div>
+                    </div>
+                </uib-tab>
+                <uib-tab heading="Advanced">
+                    <br />
+                    <div class="alert alert-warning">These options are currently experimental, unstable or targeted at advanced users! Use at your own risk.</div>
+                    <br />
+                    <div class="form-group" ng-class="{error: _form.tile.background_image.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Nb. of columns (default 12)</label>
+                        <div class="col-lg-3 col-md-3">
+                            <input name="name" type="number" ng-model="form.columns" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group" ng-class="{error: _form.tile.background_image.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Margin between widgets (default 5)</label>
+                        <div class="col-lg-3 col-md-3">
+                            <input name="name" type="number" ng-model="form.widget_margin" class="form-control" />
+                        </div>
+                    </div>
+                </uib-tab>
+            </uib-tabset>
 
         </div>
         


### PR DESCRIPTION
Added 2 options in the Advanced tab of the dashboard settings page:
- number of columns (this allows to control the width and height unit) ;
- margin between widgets.

These options are marked experimental/for experts only for now.

Closes #61.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>