### PR TITLE
removed overlay from dashboard tile (which has also just been removed…

### DIFF
--- a/src/main/java/org/openhab/ui/habpanel/internal/HABPanelDashboardTile.java
+++ b/src/main/java/org/openhab/ui/habpanel/internal/HABPanelDashboardTile.java
@@ -34,7 +34,7 @@ public class HABPanelDashboardTile implements DashboardTile {
 
     @Override
     public String getOverlay() {
-        return "html5";
+        return null;
     }
 
     @Override


### PR DESCRIPTION
… on all other UIs)

Signed-off-by: Kai Kreuzer <kai@openhab.org>