### PR TITLE
fixed config id

### DIFF
--- a/OSGI-INF/dashboardtile.xml
+++ b/OSGI-INF/dashboardtile.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.openhab.ui.habpanel">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.openhab.habpanel">
    <implementation class="org.openhab.ui.habpanel.internal.HABPanelDashboardTile"/>
    <reference bind="setHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static" unbind="unsetHttpService"/>
    <property name="service.config.description.uri" type="String" value="ui:habpanel"/>


### PR DESCRIPTION
Just noticed that this was not following the standard procedure.
With this change, it is also possible to add static configuration in conf/services/habpanel.cfg.
Unfortunately, this change is breaking, i.e. existing configurations need to be moved from `userdata/config/org/openhab/ui/habpanel.config` to `userdata/config/org/openhab/habpanel.config` by the users.
But better do the change now, before the release, than after it...

Signed-off-by: Kai Kreuzer <kai@openhab.org>