### PR TITLE
Add Content-Security-Policy meta tag

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,7 @@
     <meta name="description" content="Dashboard user interface for openHAB" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'sha256-be96PoKdQsq6Xxl4N0LIZwEFTrUQ0BECiOqanNW3Oec='">
 
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="stylesheet" href="vendor/vendor.min.css" />


### PR DESCRIPTION
Helps mitigate XSS attacks inside expressions and through lazy
loading of external scripts by templates/custom widgets.

With this CSP policy, only local scripts can be loaded
(provided the browser has support for CSP).

WARNING: the user is still responsible for securing the
openHAB instance properly, especially the REST API endpoints
which modify data (POST /service/org.openhab.habpanel/config in
particular), including custom code, and *never* publish them
unsecured on the Internet.

HABPanel lets the user modify templates, and implicitly trusts
the code in these templates, therefore XSS attacks and arbitrary
code execution is always possible even with the expression sandbox!

See: https://docs.angularjs.org/guide/security

Signed-off-by: Yannick Schaus <habpanel@schaus.net>