### PR TITLE
Use and update transformed states in switch/dummy/template

### DIFF
--- a/web/app/widgets/dummy/dummy.widget.js
+++ b/web/app/widgets/dummy/dummy.widget.js
@@ -47,7 +47,7 @@
                 vm.value = "N/A";
                 return;
             }
-            var value = item.state;
+            var value = item.transformedState || item.state;
             if (vm.widget.format) {
                 if (item.type === "DateTime" || item.type === "DateTimeItem") {
                     value = $filter('date')(value, vm.widget.format);

--- a/web/app/widgets/switch/switch.tpl.html
+++ b/web/app/widgets/switch/switch.tpl.html
@@ -8,7 +8,7 @@
                 <i class="glyphicon glyphicon-off" ng-show="vm.value=='OFF'"></i>
                 <i class="glyphicon glyphicon-record" ng-show="vm.value=='ON'"></i>
             </div>
-            <div><span ng-hide="vm.widget.hideonoff">{{vm.value}}</span></div>
+            <div><span ng-hide="vm.widget.hideonoff">{{vm.label}}</span></div>
         </div>
     </div>
 </div>

--- a/web/app/widgets/switch/switch.widget.js
+++ b/web/app/widgets/switch/switch.widget.js
@@ -60,7 +60,8 @@
                     vm.value = 'OFF';
                 }
             } else {
-                vm.value = OHService.getItem(vm.widget.item).state;
+                vm.value = item.state;
+                vm.label = item.transformedState || item.state;
             }
             
         }

--- a/web/app/widgets/template/template.widget.js
+++ b/web/app/widgets/template/template.widget.js
@@ -68,12 +68,12 @@
                 return item;
             }
 
-            scope.itemState = function(itemname) {
+            scope.itemState = function(itemname, ignoreTransform = false) {
                 if (!itemname) return "N/A";
                 var item = OHService.getItem(itemname);
                 if (!item) return "N/A";
 
-                var value = item.state;
+                var value = (item.transformedState && !ignoreTransform) ? item.transformedState : item.state;
                 return value;
             }
  


### PR DESCRIPTION
NOTE: added a new parameter to the itemState function in templates:

    itemState(name, ignoreTransform)

ignoreTransform is false by default, meaning the transformed state
will be retrieved; if the raw state is desired, set ignoreTranform
to true.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>