### PR TITLE
Template widget: remove itemState default parameter

### DIFF
--- a/web/app/widgets/template/template.widget.js
+++ b/web/app/widgets/template/template.widget.js
@@ -68,7 +68,7 @@
                 return item;
             }
 
-            scope.itemState = function(itemname, ignoreTransform = false) {
+            scope.itemState = function(itemname, ignoreTransform) {
                 if (!itemname) return "N/A";
                 var item = OHService.getItem(itemname);
                 if (!item) return "N/A";


### PR DESCRIPTION
Fix for Safari (among others) not accepting them.

As reported in https://community.openhab.org/t/template-widget-missing/29537
Also see https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/default_parameters#Browser_compatibility

Signed-off-by: Yannick Schaus <habpanel@schaus.net>