### PR TITLE
Icon picker: allow custom icons or custom URLs

### DIFF
--- a/web/app/services/icon.service.js
+++ b/web/app/services/icon.service.js
@@ -24,6 +24,12 @@
         ////////////////
 
         function getIconUrl(iconset, icon, state) {
+            if (iconset === 'custom-icon') {
+                return '/icon/' + icon + '?format=svg' + ((state) ? '&state=' + state : '');
+            } else if (iconset === 'custom-url') {
+                return icon;
+            }
+
             var set = $filter('filter')(iconsets, {id: iconset}, true)[0];
             if (set.type === 'builtin') {
                 return 'assets/icons/' + set.id + '/' + icon + '.svg';
@@ -38,6 +44,9 @@
         }
 
         function getIconSet(iconset) {
+            if (iconset === 'custom-icon' || iconset === 'custom-url') {
+                return { colorize: false };
+            }
             return $filter('filter')(iconsets, {id: iconset}, true)[0];
         }
 
@@ -56,23 +65,29 @@
             restrict: 'AE',
             template: 
                 // TODO put this template in a HTML file
+                '<img ng-if="(iconset === \'custom-icon\' || iconset === \'custom-url\') && iconUrl" width="64px" height="64px" style="float:right; border: 0;" ng-src="{{iconUrl}}" />' +
                 '<div class="btn-group" uib-dropdown is-open="status.isopen2">' +
                 '<a href id="iconset-picker-btn" class="btn btn-default" uib-dropdown-toggle>' +
                 '{{setdropdownlabel}}&nbsp;<span class="caret" /></a>' +
                 '<ul class="dropdown-menu" role="menu" aria-labelledby="iconset-picker-btn">' +
                 '<li><a ng-click="clearIcon()"><i>(none)</i></a></li>' +
                 '<li ng-repeat="iconset in iconsets"><a ng-click="selectIconset(iconset.id)">{{iconset.name}}</a></li>' +
+                '<li class="divider"></li>' +
+                '<li><a ng-click="selectCustomIcon()">Custom icon</li>' +
+                '<li><a ng-click="selectCustomURL()">Custom URL</li>' +
                 '</ul>' +
-                '</div><br />' +
-                '<div ng-if="iconset" class="btn-group" uib-dropdown is-open="status.isopen">' +
+                '</div><br /><br />' +
+                '<div ng-if="iconset && iconset !== \'custom-icon\' && iconset !== \'custom-url\'" class="btn-group" uib-dropdown is-open="status.isopen">' +
                 '<a href id="icon-picker-btn" class="btn btn-default" uib-dropdown-toggle>' +
                 '<img width="64px" height="64px" ng-src="{{iconUrl}}" />&nbsp;{{icon}}&nbsp;<span class="caret" />' +
                 '</a>' +
                 '<ul style="width: 420px" class="dropdown-menu" role="menu" aria-labelledby="icon-picker-btn">' +
                 '<li class="iconpicker-icon" style="display: inline-flex" ng-repeat="icon in icons"><a style="display:inline" ng-click="selectIcon(icon)"><img width="64px" height="64px" ng-src="{{iconService.getIconUrl(iconset, icon)}}" /><!--&nbsp;{{icon}}--></a></li> ' +
                 '</ul>' +
+                '<br /><br /><small ng-if="notice" style="display:inherit"><a target="_blank" href="{{noticeUrl}}">{{notice}}</a></small><br />' +
                 '</div>' +
-                '<br /><small ng-if="notice"><a target="_blank" href="{{noticeUrl}}">{{notice}}</a></small><br />',
+                '<div ng-show="iconset === \'custom-icon\'">Name:&nbsp;<input type="text" ng-model="icon" ng-model-options="{ updateOn: \'blur\' }" uib-tooltip-html="customIconTooltip" tooltip-trigger="focus" tooltip-placement="right" /><br /><br /></div>' +
+                '<div ng-show="iconset === \'custom-url\'">URL:&nbsp;<input type="text" ng-model="icon" ng-model-options="{ updateOn: \'blur\' }" /><br /><br /></div>',
             scope: {
                 iconset: '=',
                 icon: '='
@@ -95,6 +110,16 @@
                 scope.icon = icon;
             };
 
+            scope.selectCustomIcon = function () {
+                scope.clearIcon();
+                scope.iconset = 'custom-icon';
+            }
+
+            scope.selectCustomURL = function () {
+                scope.clearIcon();
+                scope.iconset = 'custom-url';
+            }
+
             scope.clearIcon = function () {
                 scope.icons = [];
                 scope.icon = undefined;
@@ -106,7 +131,13 @@
 
             scope.$watch('iconset', function (iconset) {
                 if (!iconset) {
-                    scope.setdropdownlabel = "Select icon set";
+                    scope.setdropdownlabel = 'Select icon set';
+                    return;
+                } else if (iconset === 'custom-icon') {
+                    scope.setdropdownlabel = 'Custom icon';
+                    return;
+                } else if (iconset === 'custom-url') {
+                    scope.setdropdownlabel = 'Custom URL';
                     return;
                 }
                 var set = IconService.getIconSet(iconset);
@@ -120,10 +151,12 @@
             });
 
             scope.$watch('icon', function (set) {
+                scope.iconUrl = '';
                 if (!scope.iconset || !scope.icon) return;
                 scope.iconUrl = IconService.getIconUrl(scope.iconset, scope.icon);
             });
 
+            scope.customIconTooltip = 'Type the name of a <a href="http://docs.openhab.org/configuration/items.html#icons" target="_blank">registered icon</a> (only SVG supported)<br />Examples: <em>switch</em>, <em>temperature</em> or an additional icon in your configuration\'s <code>icons/classic</code> folder';
 
         }
     }


### PR DESCRIPTION
Add options to the icon picker to select custom registered icons
(according to http://docs.openhab.org/configuration/items.html#icons)
or a custom URL, without breaking the existing API.

Custom icons are "state-aware": for example, 'myicon' will display
myicon-on.svg resp. switch-off.svg when the item's state is 'ON' resp. 'OFF'.

Custom URLs includes all image formats supported by the browser:  SVG, PNG, JPEG, GIF etc.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>