### PR TITLE
Import widgets from a GitHub repository

### DIFF
--- a/web/app/settings/settings.widgets.list.html
+++ b/web/app/settings/settings.widgets.list.html
@@ -9,18 +9,21 @@
 
 <br />
 
+<div uib-alert ng-if="vm.updatedMessage" type="info" close="vm.updatedMessage = null">{{vm.updatedMessage}}</div>
+<div uib-alert ng-if="vm.updateErrorMessage" type="danger" close="vm.updateErrorMessage = null">{{vm.updateErrorMessage}}</div>
+
 <div class="scrollable">
 
 <div class="col-sm-12 widgetlist">
     <div class="col-sm-4" ng-repeat="(id, widget) in configWidgets">
         <div class="widgettile col-sm-12 box">
-            <div class="pull-right box-header-btns" uib-dropdown>
+            <div class="pull-right box-header-btns" uib-dropdown dropdown-append-to-body="true">
                 <i class="glyphicon glyphicon-check"
                    uib-tooltip="This widget was provisioned globally via a bundle. It cannot be modified, but may be cloned to an user-defined widget with another name."
                    tooltip-placement="bottom-right"></i>
                 <a uib-dropdown-toggle class="settings-btn" ng-click><i class="glyphicon glyphicon-option-vertical"></i></a>
                     <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="template-actions">
-                        <li class="menuitem"><a ng-click="vm.cloneConfigWidget(id, widget)"><i class="glyphicon glyphicon-export">&nbsp;</i>Clone widget...</a></li>
+                        <li class="menuitem"><a ng-click="vm.cloneConfigWidget(id, widget)"><i class="glyphicon glyphicon-duplicate">&nbsp;</i>Clone widget...</a></li>
                     </ul>
             </div>
             <div>
@@ -31,14 +34,17 @@
 
     <div class="col-sm-4" ng-repeat="(id, widget) in customwidgets">
         <div class="widgettile col-sm-12 box activefeedback">
-            <div class="pull-right box-header-btns" uib-dropdown>
+            <div class="pull-right box-header-btns" uib-dropdown dropdown-append-to-body="true">
                 <i class="glyphicon glyphicon-expand"
                    uib-tooltip="This widget has been defined manually in this panel configuration and can be modified."
                    tooltip-placement="bottom-right"></i>
                 <a uib-dropdown-toggle class="settings-btn" ng-click><i class="glyphicon glyphicon-option-vertical"></i></a>
                     <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="template-actions">
                         <li class="menuitem"><a ng-click="vm.exportToFile(id, widget)"><i class="glyphicon glyphicon-export">&nbsp;</i>Export to file</a></li>
-                        <li class="divider" />
+                        <li class="divider" ng-if="widget.source_url || widget.readme_url"></li>
+                        <li class="menuitem" ng-if="widget.readme_url"><a href="{{widget.readme_url}}" target="_blank"><i class="glyphicon glyphicon-question-sign">&nbsp;</i>Open Readme</a>
+                        <li class="menuitem" ng-if="widget.source_url"><a ng-click="vm.updateWidget(id)"><i class="glyphicon glyphicon-retweet">&nbsp;</i>Update...</a>
+                        <li class="divider"></li>
                         <li class="menuitem"><a ng-click="vm.deleteWidget(id)"><i class="glyphicon glyphicon-trash">&nbsp;</i>Delete</a>
                     </ul>
             </div>
@@ -49,23 +55,28 @@
     </div>
 </div>
 
-
 <div class="col-sm-12">
     <br /><br /><br />
 
-    <a class="btn btn-primary" ng-click="vm.addNewWidget()">
+    <button class="btn btn-primary" ng-click="vm.addNewWidget()">
         New widget...
-    </a>
+    </button>
 
-    <a class="btn btn-primary" ng-click="vm.showImportDialog()">
-        Import...
-    </a>
+    <span class="btn-group" uib-dropdown is-open="import-dropdown-open">
+        <button id="import-button" class="btn btn-primary" uib-dropdown-toggle>
+            Import widget <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="import-button">
+            <li role="menuitem"><a ng-click="vm.showImportDialog()">Import from file...</a></li>
+            <li role="menuitem"><a ng-click="vm.showImportGitHubDialog()">Import from GitHub...</a></li>
+        </ul>
+    </span>
+
     <input style="display: none" type="file" id="widget-file-select" local-file-select="file" on-file-selected="vm.importFile" />
 
     <br /><br />
-
-
     <a href="https://community.openhab.org/tags/c/apps-services/habpanel/widget" target="_blank">Get widgets from the openHAB community</a>
 </div>
+
 
 </div>

--- a/web/app/settings/settings.widgets.list.import-github.js
+++ b/web/app/settings/settings.widgets.list.import-github.js
@@ -25,6 +25,8 @@
             vm.loadingRepo = true;
             vm.error = null;
             vm.importableWidgets = vm.updatableWidgets = 0;
+            vm.progressMax = 4;
+            vm.progressCurrent = 0;
 
             try {
                 if (vm.repoId.indexOf('/') < 0 || vm.repoId.indexOf('/') !== vm.repoId.lastIndexOf('/')) return;
@@ -32,9 +34,11 @@
                 .then(function (resp) {
                     if (resp.data) {
                         vm.repoDetails = resp.data;
+                        vm.progressCurrent = 1;
                         $http.get('https://api.github.com/repos/' + vm.repoId + '/readme',
                         { headers: { 'Accept': 'application/vnd.github.v3.html' } }
                         ).then(function (readme) {
+                            vm.progressCurrent = 2;
                             if (readme.data) {
                                 vm.readme = readme.data;
                             }
@@ -42,6 +46,7 @@
                             $http.get('https://api.github.com/repos/' + vm.repoId + '/contents')
                             .then(function (resp) {
                                 if (resp.data) {
+                                    vm.progressCurrent = 3;
                                     var widgetrequests = [];
                                     angular.forEach(resp.data, function (file) {
                                         if (file.name.indexOf('.widget.json') > 0) {
@@ -50,6 +55,7 @@
                                     });
 
                                     $q.all(widgetrequests).then(function (widgets) {
+                                        vm.progressCurrent = 4;
                                         angular.forEach(widgets, function (widget) {
                                             if (!vm.widgets) vm.widgets = {};
 

--- a/web/app/settings/settings.widgets.list.import-github.js
+++ b/web/app/settings/settings.widgets.list.import-github.js
@@ -1,0 +1,114 @@
+(function() {
+'use strict';
+
+    angular
+        .module('app')
+        .controller('WidgetImportGitHubCtrl', WidgetImportGitHubController);
+
+    WidgetImportGitHubController.$inject = ['$scope', '$rootScope', '$http', '$q', '$uibModalInstance', 'prompt', 'PersistenceService'];
+    function WidgetImportGitHubController($scope, $rootScope, $http, $q, $modalInstance, prompt, PersistenceService) {
+        var vm = this;
+
+        vm.getRateLimits = function () {
+            $http.get('https://api.github.com/rate_limit').then(function (resp) {
+                if (resp.data && resp.data.resources) vm.rateLimit = resp.data.resources.core;
+            });
+        }
+
+        vm.fetchRepo = function () {
+            if (!vm.repoId) return;
+            if (vm.repoId.indexOf('https://github.com/') === 0) {
+                vm.repoId = vm.repoId.replace('https://github.com/', '');
+            }
+
+            vm.widgets = null;
+            vm.loadingRepo = true;
+            vm.error = null;
+            vm.importableWidgets = vm.updatableWidgets = 0;
+
+            try {
+                if (vm.repoId.indexOf('/') < 0 || vm.repoId.indexOf('/') !== vm.repoId.lastIndexOf('/')) return;
+                $http.get('https://api.github.com/repos/' + vm.repoId)
+                .then(function (resp) {
+                    if (resp.data) {
+                        vm.repoDetails = resp.data;
+                        $http.get('https://api.github.com/repos/' + vm.repoId + '/readme',
+                        { headers: { 'Accept': 'application/vnd.github.v3.html' } }
+                        ).then(function (readme) {
+                            if (readme.data) {
+                                vm.readme = readme.data;
+                            }
+
+                            $http.get('https://api.github.com/repos/' + vm.repoId + '/contents')
+                            .then(function (resp) {
+                                if (resp.data) {
+                                    var widgetrequests = [];
+                                    angular.forEach(resp.data, function (file) {
+                                        if (file.name.indexOf('.widget.json') > 0) {
+                                            widgetrequests.push($http.get(file.download_url, { widget_id: file.name.replace('.widget.json', '') }));
+                                        }
+                                    });
+
+                                    $q.all(widgetrequests).then(function (widgets) {
+                                        angular.forEach(widgets, function (widget) {
+                                            if (!vm.widgets) vm.widgets = {};
+
+                                            if (widget.data && widget.data && widget.data.template) {
+                                                if (PersistenceService.getCustomWidget(widget.config.widget_id)) {
+                                                    widget.data.is_update = true;
+                                                    vm.updatableWidgets += 1;
+                                                }
+                                                vm.importableWidgets += 1;
+                                                widget.data.source_url = widget.config.url;
+                                                widget.data.readme_url = "https://github.com/" + vm.repoId;
+                                                vm.widgets[widget.config.widget_id] = widget.data;
+                                            }
+                                        });
+
+                                        vm.loadingRepo = false;
+                                    });
+                                }
+                            });
+                        })
+                    }
+                });
+            } catch (e) {
+                vm.error = JSON.stringify(e);
+                vm.loadingRepo = false;
+                vm.repoDetails = undefined;
+            } finally {
+                vm.getRateLimits();
+            }
+        }
+
+        vm.importWidget = function (id, update) {
+            var widget = angular.copy(vm.widgets[id]);
+            delete widget.is_update;
+            $rootScope.customwidgets[id] = widget;
+            vm.widgets[id].imported = true;
+            vm.importableWidgets -= 1;
+            if (update) vm.updatableWidgets -= 1;
+            PersistenceService.saveDashboards();
+        }
+
+        $scope.dismiss = function () {
+            $modalInstance.dismiss();
+        };
+
+        $scope.submit = function () {
+            if (vm.updatableWidgets > 0) {
+                prompt({
+                    title: "Existing widgets detected",
+                    message: "Warning: please confirm you wish to update " + vm.updatableWidgets + " existing widgets, overwriting any eventual changes made locally! If unsure, cancel and click Show details to review the list of affected widgets.",
+                }).then(function () {
+                    $modalInstance.close(vm.widgets);
+                });
+            } else {
+                $modalInstance.close(vm.widgets);
+            }
+        };
+
+        vm.getRateLimits();
+
+    }
+})();

--- a/web/app/settings/settings.widgets.list.import-github.tpl.html
+++ b/web/app/settings/settings.widgets.list.import-github.tpl.html
@@ -36,6 +36,7 @@
         width: 4.2em;
         margin-right: 15px;
         position: absolute;
+        left: 2em;
     }
 
     .repo-header .repo-title {

--- a/web/app/settings/settings.widgets.list.import-github.tpl.html
+++ b/web/app/settings/settings.widgets.list.import-github.tpl.html
@@ -98,6 +98,7 @@
                 </div>
             </div>
             <hr class="row" />
+            <uib-progressbar max="vm.progressMax" value="vm.progressCurrent" class="progress-striped active" ng-show="vm.loadingRepo"></uib-progressbar>
             <div>
                 <div ng-if="!vm.loadingRepo && vm.repoDetails" class="panel panel-default">
                     <div class="panel-heading repo-header">

--- a/web/app/settings/settings.widgets.list.import-github.tpl.html
+++ b/web/app/settings/settings.widgets.list.import-github.tpl.html
@@ -1,0 +1,162 @@
+<style>
+    /* Inline styles are sort of OK here since this template is lazy-loaded... */
+
+    .readme h1 {
+        color: black;
+        font-size: 18pt;
+        margin: inherit;
+        text-align: inherit;
+        position: inherit;
+        width: inherit;
+        padding-bottom: 10px;
+    }
+
+    .readme h2 {
+        color: black;
+        font-size: 16pt;
+        padding-bottom: 6px;
+    }
+
+    .readme h3 {
+        color: black;
+        font-size: 14pt;
+    }
+
+    .readme h4 {
+        color: black;
+        font-size: 12pt;
+    }
+
+    .readme ul {
+        list-style: inherit;
+    }
+
+    .repo-header .avatar {
+        height: 4.2em;
+        width: 4.2em;
+        margin-right: 15px;
+        position: absolute;
+    }
+
+    .repo-header .repo-title {
+        color: black;
+    }
+
+    .repo-header .repo-info {
+        padding-left: 5em;
+    }
+
+    .repo-header .import-btn {
+        margin-left: 3em;
+        margin-top: 8px;
+    }
+
+    .widget-details.thumbnail {
+        height: 220px;
+    }
+
+    .widget-details.thumbnail .caption .title {
+        height: 1.2em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        white-space: nowrap;
+    }
+
+    .widget-details.thumbnail .caption .description {
+        height: 100px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        -webkit-line-clamp: 5;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+    }
+</style>
+
+<div>
+    <form name="_form" class="form-horizontal" ng-submit="submit(_form)">
+        <div class="modal-header">
+            <button type="button" class="close" ng-click="dismiss()" aria-hidden="true">&times;</button>
+            <h3>Import Widgets from GitHub</h3>
+        </div>
+
+        <div class="modal-body">
+            <div ng-if="vm.rateLimit.remaining < 3" uib-alert type="danger">Warning: rate limiting on the GitHub API will temporarily block further requests!
+                Wait until {{vm.rateLimit.reset*1000 | date:'HH:mm:ss'}} and try again.
+            </div>
+            <div class="row">
+                <div class="col-xs-12">
+                    <div class="input-group">
+                        <input name="name" type="text" ng-model="vm.repoId" class="form-control" placeholder="Repository full name (owner/name) or URL"
+                        />
+                        <span class="input-group-btn">
+                            <button class="btn btn-default" style="padding-bottom: 7px" type="button" ng-click="vm.fetchRepo()">Go</button>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            <hr class="row" />
+            <div>
+                <div ng-if="!vm.loadingRepo && vm.repoDetails" class="panel panel-default">
+                    <div class="panel-heading repo-header">
+                        <img ng-src="{{vm.repoDetails.owner.avatar_url}}" class="avatar" />
+                        <div class="col-md-8 repo-info">
+                            <h4><a class="repo-title" href="{{vm.repoDetails.html_url}}" target="_blank">{{vm.repoDetails.name}}</a> <small>by <a href="{{vm.repoDetails.owner.html_url}}" target="_blank">{{vm.repoDetails.owner.login}}</a>&nbsp;|&nbsp;<i class="glyphicon glyphicon-star"></i>&nbsp;{{vm.repoDetails.stargazers_count}}</small></h4>
+                            <div>{{vm.repoDetails.description}}</div>
+                            <small><a ng-if="vm.repoDetails.homepage" href="{{vm.repoDetails.homepage}}" target="_blank"><i class="glyphicon glyphicon-globe"></i>&nbsp;{{vm.repoDetails.homepage}}</a></small>
+                        </div>
+                        <div class="col-md-4">
+                            <button type="button" class="btn btn-lg btn-success import-btn" ng-click="submit()" ng-disabled="vm.importableWidgets < 1">
+                                <ng-pluralize count="vm.importableWidgets"
+                                    when="{'0': 'No widgets to import.',
+                                           'one': 'Import Widget',
+                                           'other': 'Import {} Widgets'}">
+                                </ng-pluralize>
+                                <span class="label label-warning show" ng-if="vm.updatableWidgets">{{vm.updatableWidgets}} to update</span>
+                            </button>
+                            <br /><br />
+                        </div>
+                        <div style="clear:both">
+                            <br />
+                            <span ng-hide="expandWidgets"><a ng-click="expandWidgets = true" class="btn btn-default btn-sm">Show details <span class="caret"></span></a></span>
+                            <span ng-show="expandWidgets"><a ng-click="expandWidgets = false" class="btn btn-default btn-sm">Hide details <span class="caret" style="transform: rotate(180deg);"></span></a></span>
+                            &nbsp;<a class="btn btn-default btn-sm" href="{{vm.repoDetails.archive_url.replace('{archive_format}', 'zipball').replace('{/ref}', '')}}" target="_blank">Download ZIP</a>
+                        </div>
+                    </div>
+                    <div class="col-xs-12" ng-show="expandWidgets">
+                        <br />
+                        <p class="col-xs-12">
+                            <strong ng-if="vm.widgets">This repository contains the following widgets which can be imported individually:</strong>
+                            <strong ng-if="!vm.widgets" class="text-danger">No widgets were found in this repository (*.widget.json files), try another one!</strong>
+                        </p>
+                        <div class="col-xs-6 col-sm-4" ng-repeat="(id,widget) in vm.widgets">
+                            <div class="thumbnail widget-details">
+                                <div class="caption">
+                                    <h4 class="title">{{id}}</h4>
+                                    <p class="description"><small>{{widget.description}}</small></p>
+                                    <p>
+                                        <button type="button" ng-if="!widget.imported && !widget.is_update" ng-click="vm.importWidget(id)" class="btn btn-sm btn-success">Import widget</button>
+                                        <button type="button" ng-if="!widget.imported && widget.is_update" ng-click="vm.importWidget(id, true)" class="btn btn-sm btn-warning">Update widget</button>
+                                        <button type="button" ng-if="widget.imported" class="btn btn-sm btn-primary" disabled="disabled">Widget imported!</button>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <hr style="clear:both" />
+                    </div>
+                    <div class="panel-body">
+                        <div ng-bind-html="vm.readme" class="readme"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div ng-if="!vm.loadingRepo && vm.error" class="alert alert-danger">Error: {{vm.error}}</div>
+        <div ng-if="!vm.loadingRepo && !vm.repoDetails" class="alert alert-warning">Caution: Always be careful when importing widgets from unknown sources!</div>
+
+        <div class="modal-footer">
+            <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
+        </div>
+    </form>
+</div>


### PR DESCRIPTION
Adds a dialog in the Custom Widgets screen to easily import widgets from a GitHub repository.
Uses the rate-limited GitHub API in anonymous mode (60 requests per hour).

Takes care of already existing widgets - update them in this case.

Added menu entries to easily update and check the Readme file for widgets imported from GitHub.

Can be reused/extended for other sources (Eclipse IoT Marketplace?).

Signed-off-by: Yannick Schaus <habpanel@schaus.net>