### PR TITLE
Experimental feature: custom widgets on main menu

### DIFF
--- a/web/app/menu/menu.html
+++ b/web/app/menu/menu.html
@@ -56,13 +56,17 @@
         </div>
     </div>
     <div ng-if="!vm.editMode" gridster="vm.gridsterOptions" class="col-md-12 col-lg-12">
-        <div gridster-item="dash" ng-init="tile=dash.tile" class="dash-card col-md-6 col-lg-6 col-sm-6 box activefeedback" ng-repeat="dash in vm.dashboards">
-            <h3 ng-style="{ color:(tile.title_color && tile.title_color!='transparent')?tile.title_color:'inherit' }" ng-click="vm.viewDashboard(dash)" class="card-title">
+        <div gridster-item="dash" ng-init="tile=dash.tile" class="dash-card col-md-6 col-lg-6 col-sm-6 box" ng-class="{ activefeedback: !tile.no_click_feedback }" ng-repeat="dash in vm.dashboards">
+            <h3 ng-if="!tile.use_custom_widget" ng-style="{ color:(tile.title_color && tile.title_color!='transparent')?tile.title_color:'inherit' }" ng-click="vm.viewDashboard(dash)" class="card-title">
                 <img class="tile-background" ng-if="tile.background_image" ng-src="{{tile.background_image}}" />
                 <widget-icon ng-if="tile.backdrop_icon && !tile.background_image" backdrop="true" iconset="tile.backdrop_iconset" icon="tile.backdrop_icon" center="tile.backdrop_center"></widget-icon>
                 <!--<widget-icon iconset="'smarthome-set'" icon="'bulb'" backdrop="true"></widget-icon>-->
                 <div>{{dash.name}}</div>
             </h3>
+            <div ng-if="tile.use_custom_widget" ng-click="vm.viewDashboard(dash)" class="card-title" style="cursor: pointer; height: 100%"
+                 ng-init="customWidgetsModels[dash.id] = { id: dash.id, name: dash.name, nobackground: tile.custom_widget_nobackground, customwidget: tile.custom_widget, dontwrap: tile.custom_widget_dontwrap, config: tile.custom_widget_config }">
+            <widget-template ng-model="customWidgetsModels[dash.id]">
+            </widget-template>
         </div>
     </div>       
 </div>

--- a/web/app/menu/menu.settings.tpl.html
+++ b/web/app/menu/menu.settings.tpl.html
@@ -68,6 +68,16 @@
                             <div dab-model="form.tile.title_color" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
                         </div>
                     </div>
+                    <div class="form-group" ng-class="{error: _form.tile.no_click_feedback.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Click feedback</label>
+                        <div class="col-lg-9 col-md-9">
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="vertical" ng-model="form.tile.no_click_feedback" /> Don't brighten tile on click/tap
+                                </label>
+                            </div>
+                        </div>
+                    </div>
                 </uib-tab>
                 <uib-tab heading="Advanced">
                     <br />
@@ -115,6 +125,65 @@
                             <input name="name" type="number" ng-model="form.mobile_breakpoint" class="form-control" />
                         </div>
                     </div>
+                </uib-tab>
+                <uib-tab heading="Custom widget">
+                    <br />
+                    <div class="alert alert-warning">This feature is currently experimental, and targeted at advanced users! Use at your own risk.</div>
+
+                    <div class="form-group" ng-class="{error: _form.mobile_mode_enabled.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Use a custom widget</label>
+                        <div class="col-lg-9 col-md-9">
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="vertical" ng-model="form.tile.use_custom_widget" /> Replace the tile contents by a custom widget
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group" ng-if="form.tile.use_custom_widget" ng-class="{error: _form.tile.use_custom_widget.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Custom Widget</label>
+                        <div class="col-lg-9 col-md-9">
+                            <select ng-model="form.tile.custom_widget" ng-change="updateCustomWidgetSettings(true)" class="form-control">
+                                <option value=""></option>
+                                <option ng-repeat="(id, widget) in configWidgets" value="{{id}}">{{id}}</option>
+                                <option ng-repeat="(id, widget) in customwidgets" value="{{id}}">{{id}}</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div ng-if="form.tile.use_custom_widget && form.tile.custom_widget">
+                        <div class="form-group" ng-class="{error: _form.tile.custom_widget_nolinebreak.$error && _form.submitted}">
+                            <!--<label class="control-label col-lg-3 col-md-3"></label>-->
+                            <div class="col-lg-8 col-md-8">
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" name="vertical" ng-model="form.tile.custom_widget_dontwrap" /> Don't wrap in container
+                                    </label>
+                                    &nbsp;&nbsp;
+                                    <label>
+                                        <input type="checkbox" name="vertical" ng-model="form.tile.custom_widget_nobackground" /> No background
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <hr />
+                        <div class="form-group" ng-repeat="setting in widgetsettings">
+                            <label ng-if="setting.type !== 'heading'" class="control-label col-lg-3 col-md-3">{{setting.label || setting.id}}</label>
+                            <div class="col-lg-9 col-md-9" ng-switch="setting.type">
+                                <h4 ng-if="setting.type === 'heading'">{{setting.label}}</h4>
+                                <input ng-switch-when="string" type="text" ng-model="form.tile.custom_widget_config[setting.id]" class="form-control">
+                                <input ng-switch-when="number" type="number" ng-model="form.tile.custom_widget_config[setting.id]" class="form-control" step="any" style="width: 120px">
+                                <div ng-switch-when="checkbox" style="padding-top: 7px"><input type="checkbox" ng-model="form.tile.custom_widget_config[setting.id]"> {{setting.description}}</div>
+                                <item-picker ng-switch-when="item" ng-model="form.tile.custom_widget_config[setting.id]"></item-picker>
+                                <select ng-switch-when="choice" ng-options="choice for choice in setting.choices.split(',')" ng-model="form.tile.custom_widget_config[setting.id]" class="form-control"></select>
+                                <icon-picker ng-switch-when="icon" iconset="form.tile.custom_widget_config[setting.id + '_iconset']" icon="form.tile.custom_widget_config[setting.id]"></icon-picker>
+                                <div ng-switch-when="color" dab-model="form.tile.custom_widget_config[setting.id]" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
+                                <div ng-if="setting.type !== 'checkbox'"><small>{{setting.description}}</small></div>
+                            </div>
+                        </div>
+                    </div>
+
                 </uib-tab>
             </uib-tabset>
 


### PR DESCRIPTION
This provides the ability to use a custom widget as a main menu tile, including
setting its config, thus allowing dynamic content on the main menu.

The widgets can be clicked like a normal tile, so no need to handle click events
in the widget's template - in fact, any kind of interactivity is discouraged.

You can use `ngModel.name` in the widget template to retrieve the dashboard label.

Also added the ability to prevent the tile from "brightening up" when clicked.

Removed the $interval for the old clock in the main menu controller.

Closes #34, #108.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>