### PR TITLE
Improve the initial rendering of several widgets

### DIFF
--- a/web/app/widgets/chart/chart.tpl.html
+++ b/web/app/widgets/chart/chart.tpl.html
@@ -6,6 +6,6 @@
         <img ng-src="/rrdchart.png?{{vm.imageQueryString()}}&h={{vm.height}}&w={{vm.width}}" />
     </div>
     <div class="chart-content" ng-if="vm.widget.charttype==='interactive'" style="height: calc(100% - 2em)">
-        <linechart data="vm.datasets" options="vm.interactiveChartOptions"></linechart>
+        <linechart ng-if="vm.interactiveChartReady" data="vm.datasets" options="vm.interactiveChartOptions"></linechart>
     </div>
 </div>

--- a/web/app/widgets/colorpicker/colorpicker.tpl.html
+++ b/web/app/widgets/colorpicker/colorpicker.tpl.html
@@ -1,5 +1,5 @@
 <div class="box-content colorpicker">
-    <div class="colorpicker-content" ng-show="!vm.widget.style || vm.widget.style === 'default'">
+    <div class="colorpicker-content" ng-show="(!vm.widget.style || vm.widget.style === 'default') && vm.ready">
 
         <span>{{vm.widget.name}}</span>
 

--- a/web/app/widgets/colorpicker/colorpicker.widget.js
+++ b/web/app/widgets/colorpicker/colorpicker.widget.js
@@ -199,12 +199,12 @@
                 vm.aCKolorModel = vm.value = 'hsl(' + hsl[0] + ', ' + hsl[1] + '%, ' + hsl[2] + '%)';
                 console.log(vm.aCKolorModel);
             }
+
+            vm.ready = true;
         }
 
         OHService.onUpdate($scope, vm.widget.item, function () {
-            $timeout(function() {
-                updateValue();
-            }, 0);
+            updateValue();
         });
 
         vm.valueChanged = function(val) {

--- a/web/app/widgets/slider/slider.tpl.html
+++ b/web/app/widgets/slider/slider.tpl.html
@@ -3,7 +3,7 @@
     <div ng-class="{ 'slider-content': !vm.widget.vertical, 'slider-content-vertical': vm.widget.vertical }">
         <div class="slider-label" ng-hide="vm.widget.hidelabel">{{vm.widget.name}}</div>
         <div class="slider-container" ng-class="{ bigslider: vm.widget.bigslider }">
-            <rzslider rz-slider-model="vm.slider.value" rz-slider-options="vm.slider.options" data-snap-ignore="true"></rzslider>
+            <rzslider rz-slider-model="vm.slider.value" rz-slider-options="vm.slider.options" data-snap-ignore="true" ng-if="vm.ready"></rzslider>
         </div>
     </div>
 </div>

--- a/web/app/widgets/slider/slider.widget.js
+++ b/web/app/widgets/slider/slider.widget.js
@@ -88,19 +88,13 @@
             }
         };
 
-        var initialValue = getValue();
-        vm.value = vm.slider.value = angular.isDefined(getValue()) ? getValue() : 0;
-        $timeout(function() {
-            $scope.$broadcast('rzSliderForceRender');
-        })
-
         function updateValue() {
             var value = getValue();
 
             if (!isNaN(value) && value != vm.slider.value) {
                 $timeout(function () {
                     vm.value = vm.slider.value = value;
-                    $scope.$broadcast('rzSliderForceRender');
+                    vm.ready = true;
                 });
             }
 

--- a/web/app/widgets/template/template.widget.js
+++ b/web/app/widgets/template/template.widget.js
@@ -14,8 +14,8 @@
             });
         });
 
-    widgetTemplate.$inject = ['$rootScope', '$compile', '$filter', 'OHService', '$uibModal'];
-    function widgetTemplate($rootScope, $compile, $filter, OHService, $uibModal) {
+    widgetTemplate.$inject = ['$rootScope', '$compile', '$timeout', '$filter', 'OHService', '$uibModal'];
+    function widgetTemplate($rootScope, $compile, $timeout, $filter, OHService, $uibModal) {
         // Usage: <widget-template ng-model="widget" />
         //
         // Creates: A template widget
@@ -111,6 +111,11 @@
                     animation: !noAnimation,
                     scope: scope
                 });
+
+                // hack to give widgets a chance to refresh themselves
+                $timeout(function () {
+                    $rootScope.$broadcast('openhab-update');
+                })
             }
 
             scope.$on("refreshTemplate", function () {


### PR DESCRIPTION
- slider: Wait for the first event to display the widget (this hack
  seems to fix a long-standing display glitch e.g. when switching dashboards);
- chart: attempt to get rid the the initial data series animations;
- colorpicker: remove the initial "flickering";
- template: send an update event after opening a modal dialog

Signed-off-by: Yannick Schaus <habpanel@schaus.net>