### PR TITLE
Experimental: use custom widgets for drawer and headers

### DIFF
--- a/web/app/dashboard/dashboard.view.html
+++ b/web/app/dashboard/dashboard.view.html
@@ -3,19 +3,19 @@
         <i class="glyphicon glyphicon-menu-hamburger"></i>
     </a>
 
-    <a class="btn pull-right" ng-click="vm.goFullscreen()" title="Toggle full screen" ng-if="!settings.hide_fullscreen_button">
+    <a class="btn pull-right" ng-click="vm.goFullscreen()" title="Toggle full screen" ng-if="!settings.hide_fullscreen_button && !vm.dashboard.header.use_custom_widget">
         <i class="glyphicon glyphicon-resize-full"></i>
     </a>
-    <a class="btn pull-right" ng-click="vm.refresh()" title="Refresh" ng-if="!settings.hide_refresh_button">
+    <a class="btn pull-right" ng-click="vm.refresh()" title="Refresh" ng-if="!settings.hide_refresh_button && !vm.dashboard.header.use_custom_widget">
         <i class="glyphicon glyphicon-refresh"></i>
     </a>
     <a class="btn pull-right" 
-        ng-if="vm.supportsSpeech && !settings.floating_speech && !settings.hide_speak_button" 
+        ng-if="vm.supportsSpeech && !settings.floating_speech && !settings.hide_speak_button && !vm.dashboard.header.use_custom_widget" 
         ng-click="vm.isListening ? vm.stopListening() : vm.listen()" 
         title="Speak">
         <i class="glyphicon" ng-class="vm.isListening ? 'glyphicon-stop' : 'glyphicon-comment'"></i>
     </a>
-    <h2 class="dashboard-title">
+    <h2 class="dashboard-title" ng-if="!vm.dashboard.header.use_custom_widget">
         <small class="header-clock" ng-if="settings.show_header_clock"><ds-widget-clock show-digital digital-format="settings.header_clock_format || 'HH:mm'"></ds-widget-clock></small>
         <span>{{vm.dashboard.name}}
             <a class="btn btn-link btn-edit-dashboard"
@@ -26,6 +26,11 @@
             </a>
         </span>
     </h2>
+    <div ng-if="vm.dashboard.header.use_custom_widget"
+         ng-init="customHeaderWidgetModel = { id: vm.dashboard.id, name: vm.dashboard.name, nobackground: true, customwidget: vm.dashboard.header.custom_widget, dontwrap: true, config: vm.dashboard.header.custom_widget_config }">>
+        <widget-template ng-model="customHeaderWidgetModel">
+        </widget-template>
+    </div>
 </div>
 <span ng-if="vm.isListening" class="speech-output">{{vm.speechOutput}}</span>
 <a class="btn fab" 

--- a/web/app/menu/drawer.tpl.html
+++ b/web/app/menu/drawer.tpl.html
@@ -3,11 +3,16 @@
         <widget-icon iconset="'freepik-housethings'" icon="'house-building'" size="40"></widget-icon> {{settings.panel_name || 'HABPanel'}}
     </li>
     <li ng-if="settings.drawer_heading_image" ng-click="goHome()" style="padding: 0">
-        <img src="{{settings.drawer_heading_image}}" />
+        <img ng-src="{{settings.drawer_heading_image}}" />
     </li>
     <li ng-repeat="dash in dashboards | orderBy:['row', 'col']" ng-class="{ active: isActive(dash.id) }" ng-click="goToDashboard(dash.id)">
-        <widget-icon ng-if="dash.tile.iconset && dash.tile.icon" style="position:absolute; right: 20px" iconset="dash.tile.iconset" icon="dash.tile.icon" inline="true" size="24"></widget-icon>
-        {{dash.name}}
+        <widget-icon ng-if="dash.tile.iconset && dash.tile.icon && !dash.drawer.use_custom_widget" style="position:absolute; right: 20px" iconset="dash.tile.iconset" icon="dash.tile.icon" inline="true" size="24"></widget-icon>
+        <span ng-if="!dash.drawer.use_custom_widget">{{dash.name}}</span>
+        <div ng-if="dash.drawer.use_custom_widget" ng-click="vm.viewDashboard(dash)" class="card-title" style="cursor: pointer; height: 100%"
+                ng-init="customDrawerWidgetsModels[dash.id] = { id: dash.id, name: dash.name, nobackground: true, customwidget: dash.drawer.custom_widget, dontwrap: true, config: dash.drawer.custom_widget_config }">
+            <widget-template ng-model="customDrawerWidgetsModels[dash.id]">
+            </widget-template>
+        </div>
     </li>
 </ul>
 <footer ng-if="!settings.hide_drawer_footer">

--- a/web/app/menu/menu.controller.js
+++ b/web/app/menu/menu.controller.js
@@ -12,7 +12,7 @@
         vm.dashboards = dashboards;
         vm.editMode = false;
         vm.customWidgetsModels = {};
-
+        vm.customDrawerWidgetsModels = {};
 
         activate();
 
@@ -140,6 +140,8 @@
     function DashboardSettingsCtrl($scope, $timeout, $rootScope, $modalInstance, dashboard, OHService, PersistenceService) {
         $scope.dashboard = dashboard;
         if (!$scope.dashboard.tile) $scope.dashboard.tile = {};
+        if (!$scope.dashboard.drawer) $scope.dashboard.drawer = {};
+        if (!$scope.dashboard.header) $scope.dashboard.header = {};
         //$scope.items = OHService.getItems();
 
         $scope.form = {
@@ -169,7 +171,17 @@
                 custom_widget: dashboard.tile.custom_widget,
                 custom_widget_dontwrap: dashboard.tile.custom_widget_dontwrap,
                 custom_widget_nobackground: dashboard.tile.custom_widget_nobackground,
-                custom_widget_config: dashboard.tile.custom_widget_config || {},
+                custom_widget_config: dashboard.tile.custom_widget_config || {}
+            },
+            drawer: {
+                use_custom_widget: dashboard.drawer.use_custom_widget,
+                custom_widget: dashboard.drawer.custom_widget,
+                custom_widget_config: dashboard.drawer.custom_widget_config || {}
+            },
+            header: {
+                use_custom_widget: dashboard.header.use_custom_widget,
+                custom_widget: dashboard.header.custom_widget,
+                custom_widget_config: dashboard.header.custom_widget_config || {}
             }
         };
 
@@ -184,17 +196,19 @@
             });
         };
 
-        $scope.updateCustomWidgetSettings = function(erase_config) {
-            delete $scope.widgetsettings;
-            if ($scope.form.tile && $scope.form.tile.use_custom_widget && $scope.form.tile.custom_widget) {
-                if ($rootScope.configWidgets[$scope.form.tile.custom_widget]) {
-                    $scope.widgetsettings = $rootScope.configWidgets[$scope.form.tile.custom_widget].settings;
-                } else if ($rootScope.customwidgets[$scope.form.tile.custom_widget]) {
-                    $scope.widgetsettings = $rootScope.customwidgets[$scope.form.tile.custom_widget].settings;
+        $scope.updateCustomWidgetSettings = function(erase_config, type) {
+            if (!$scope.widgetsettings)
+                $scope.widgetsettings = {};
+            delete $scope.widgetsettings[type];
+            if ($scope.form[type] && $scope.form[type].use_custom_widget && $scope.form[type].custom_widget) {
+                if ($rootScope.configWidgets[$scope.form[type].custom_widget]) {
+                    $scope.widgetsettings[type] = $rootScope.configWidgets[$scope.form[type].custom_widget].settings;
+                } else if ($rootScope.customwidgets[$scope.form[type].custom_widget]) {
+                    $scope.widgetsettings[type] = $rootScope.customwidgets[$scope.form[type].custom_widget].settings;
                 }
             }
-            if (erase_config && $scope.form.tile.custom_widget_config) {
-                $scope.form.tile.custom_widget_config = {};
+            if (erase_config && $scope.form[type].custom_widget_config) {
+                $scope.form[type].custom_widget_config = {};
             }
         };
 
@@ -211,6 +225,12 @@
                 delete dashboard.tile.custom_widget_dontwrap;
                 delete dashboard.tile.custom_widget_nobackground;
             }
+            if (!dashboard.drawer.use_custom_widget) {
+                delete dashboard.drawer;
+            }
+            if (!dashboard.header.use_custom_widget) {
+                delete dashboard.header;
+            }
 
             PersistenceService.saveDashboards().then(function () {
                 $rootScope.dashboards = null;
@@ -220,7 +240,9 @@
             });
         };
 
-        $scope.updateCustomWidgetSettings(false);
+        $scope.updateCustomWidgetSettings(false, 'tile');
+        $scope.updateCustomWidgetSettings(false, 'drawer');
+        $scope.updateCustomWidgetSettings(false, 'header');
     }
     
 })();

--- a/web/app/menu/menu.html
+++ b/web/app/menu/menu.html
@@ -66,8 +66,9 @@
             </h3>
             <div ng-if="tile.use_custom_widget" ng-click="vm.viewDashboard(dash)" class="card-title" style="cursor: pointer; height: 100%"
                  ng-init="customWidgetsModels[dash.id] = { id: dash.id, name: dash.name, nobackground: tile.custom_widget_nobackground, customwidget: tile.custom_widget, dontwrap: tile.custom_widget_dontwrap, config: tile.custom_widget_config }">
-            <widget-template ng-model="customWidgetsModels[dash.id]">
-            </widget-template>
+                <widget-template ng-model="customWidgetsModels[dash.id]">
+                </widget-template>
+            </div>
         </div>
     </div>       
 </div>

--- a/web/app/menu/menu.settings.tpl.html
+++ b/web/app/menu/menu.settings.tpl.html
@@ -1,3 +1,20 @@
+<script type="text/ng-template" id="app/menu/custom_widget_form.html">
+    <div class="form-group" ng-repeat="setting in widgetsettings[type]">
+        <label ng-if="setting.type !== 'heading'" class="control-label col-lg-3 col-md-3">{{setting.label || setting.id}}</label>
+        <div class="col-lg-9 col-md-9" ng-switch="setting.type">
+            <h5 ng-if="setting.type === 'heading'">{{setting.label}}</h5>
+            <input ng-switch-when="string" type="text" ng-model="form[type].custom_widget_config[setting.id]" class="form-control">
+            <input ng-switch-when="number" type="number" ng-model="form[type].custom_widget_config[setting.id]" class="form-control" step="any" style="width: 120px">
+            <div ng-switch-when="checkbox" style="padding-top: 7px"><input type="checkbox" ng-model="form[type].custom_widget_config[setting.id]"> {{setting.description}}</div>
+            <item-picker ng-switch-when="item" ng-model="form[type].custom_widget_config[setting.id]"></item-picker>
+            <select ng-switch-when="choice" ng-options="choice for choice in setting.choices.split(',')" ng-model="form[type].custom_widget_config[setting.id]" class="form-control"></select>
+            <icon-picker ng-switch-when="icon" iconset="form[type].custom_widget_config[setting.id + '_iconset']" icon="form[type].custom_widget_config[setting.id]"></icon-picker>
+            <div ng-switch-when="color" dab-model="form[type].custom_widget_config[setting.id]" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
+            <div ng-if="setting.type !== 'checkbox'"><small>{{setting.description}}</small></div>
+        </div>
+    </div>
+</script>
+
 <div>
     <form name="_form" class="form-horizontal" ng-submit="submit(_form)">
         <div class="modal-header">
@@ -15,12 +32,6 @@
                             <input name="name" type="text" ng-model="form.name" class="form-control" />
                         </div>
                     </div>
-                    <!--<div class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
-                        <label class="control-label col-lg-3 col-md-3">openHAB Item</label>
-                        <div class="col-lg-9 col-md-9">
-                            <select ng-model="form.item" ng-options="item.name as item.name for item in items" class="form-control"></select>
-                        </div>
-                    </div>-->
                     <div class="form-group" ng-class="{error: _form.tile.background_image.$error && _form.submitted}">
                         <label class="control-label col-lg-3 col-md-3">Background Image URL</label>
                         <div class="col-lg-9 col-md-9">
@@ -126,63 +137,123 @@
                         </div>
                     </div>
                 </uib-tab>
-                <uib-tab heading="Custom widget">
+                <uib-tab heading="Custom widgets">
                     <br />
-                    <div class="alert alert-warning">This feature is currently experimental, and targeted at advanced users! Use at your own risk.</div>
+                    <div class="alert alert-warning">These features are currently experimental, and targeted at advanced users! Use at your own risk.</div>
 
-                    <div class="form-group" ng-class="{error: _form.mobile_mode_enabled.$error && _form.submitted}">
-                        <label class="control-label col-lg-3 col-md-3">Use a custom widget</label>
-                        <div class="col-lg-9 col-md-9">
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" name="vertical" ng-model="form.tile.use_custom_widget" /> Replace the tile contents by a custom widget
-                                </label>
-                            </div>
-                        </div>
-                    </div>
+                    <uib-accordion close-others="true">
+                        <div uib-accordion-group class="panel-default" heading="Main menu tile{{(form.tile.use_custom_widget && form.tile.custom_widget) ? ': ' + form.tile.custom_widget : ''}}">
 
-                    <div class="form-group" ng-if="form.tile.use_custom_widget" ng-class="{error: _form.tile.use_custom_widget.$error && _form.submitted}">
-                        <label class="control-label col-lg-3 col-md-3">Custom Widget</label>
-                        <div class="col-lg-9 col-md-9">
-                            <select ng-model="form.tile.custom_widget" ng-change="updateCustomWidgetSettings(true)" class="form-control">
-                                <option value=""></option>
-                                <option ng-repeat="(id, widget) in configWidgets" value="{{id}}">{{id}}</option>
-                                <option ng-repeat="(id, widget) in customwidgets" value="{{id}}">{{id}}</option>
-                            </select>
-                        </div>
-                    </div>
-
-                    <div ng-if="form.tile.use_custom_widget && form.tile.custom_widget">
-                        <div class="form-group" ng-class="{error: _form.tile.custom_widget_nolinebreak.$error && _form.submitted}">
-                            <!--<label class="control-label col-lg-3 col-md-3"></label>-->
-                            <div class="col-lg-8 col-md-8">
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="vertical" ng-model="form.tile.custom_widget_dontwrap" /> Don't wrap in container
-                                    </label>
-                                    &nbsp;&nbsp;
-                                    <label>
-                                        <input type="checkbox" name="vertical" ng-model="form.tile.custom_widget_nobackground" /> No background
-                                    </label>
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.tile.use_custom_widget.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Use a custom widget</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="vertical" ng-model="form.tile.use_custom_widget" /> Replace the tile contents by a custom widget
+                                        </label>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <hr />
-                        <div class="form-group" ng-repeat="setting in widgetsettings">
-                            <label ng-if="setting.type !== 'heading'" class="control-label col-lg-3 col-md-3">{{setting.label || setting.id}}</label>
-                            <div class="col-lg-9 col-md-9" ng-switch="setting.type">
-                                <h4 ng-if="setting.type === 'heading'">{{setting.label}}</h4>
-                                <input ng-switch-when="string" type="text" ng-model="form.tile.custom_widget_config[setting.id]" class="form-control">
-                                <input ng-switch-when="number" type="number" ng-model="form.tile.custom_widget_config[setting.id]" class="form-control" step="any" style="width: 120px">
-                                <div ng-switch-when="checkbox" style="padding-top: 7px"><input type="checkbox" ng-model="form.tile.custom_widget_config[setting.id]"> {{setting.description}}</div>
-                                <item-picker ng-switch-when="item" ng-model="form.tile.custom_widget_config[setting.id]"></item-picker>
-                                <select ng-switch-when="choice" ng-options="choice for choice in setting.choices.split(',')" ng-model="form.tile.custom_widget_config[setting.id]" class="form-control"></select>
-                                <icon-picker ng-switch-when="icon" iconset="form.tile.custom_widget_config[setting.id + '_iconset']" icon="form.tile.custom_widget_config[setting.id]"></icon-picker>
-                                <div ng-switch-when="color" dab-model="form.tile.custom_widget_config[setting.id]" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
-                                <div ng-if="setting.type !== 'checkbox'"><small>{{setting.description}}</small></div>
+
+                            <div class="form-group" ng-if="form.tile.use_custom_widget" ng-class="{error: _form.tile.use_custom_widget.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Custom Widget</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <select ng-model="form.tile.custom_widget" ng-change="updateCustomWidgetSettings(true, 'tile')" class="form-control">
+                                        <option value=""></option>
+                                        <option ng-repeat="(id, widget) in configWidgets" value="{{id}}">{{id}}</option>
+                                        <option ng-repeat="(id, widget) in customwidgets" value="{{id}}">{{id}}</option>
+                                    </select>
+                                </div>
                             </div>
+
+                            <div ng-if="form.tile.use_custom_widget && form.tile.custom_widget">
+                                <div class="form-group" ng-class="{error: _form.tile.custom_widget_nolinebreak.$error && _form.submitted}">
+                                    <!--<label class="control-label col-lg-3 col-md-3"></label>-->
+                                    <div class="col-lg-8 col-md-8">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="vertical" ng-model="form.tile.custom_widget_dontwrap" /> Don't wrap in container
+                                            </label>
+                                            &nbsp;&nbsp;
+                                            <label>
+                                                <input type="checkbox" name="vertical" ng-model="form.tile.custom_widget_nobackground" /> No background
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                                <hr />
+                                <div ng-repeat="type in ['tile']" ng-include="'app/menu/custom_widget_form.html'"></div>
+                            </div>
+
                         </div>
-                    </div>
+
+
+                        <div uib-accordion-group class="panel-default" heading="Drawer{{(form.drawer.use_custom_widget && form.drawer.custom_widget) ? ': ' + form.drawer.custom_widget : ''}}">
+
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.drawer.use_custom_widget.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Use a custom widget</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="vertical" ng-model="form.drawer.use_custom_widget" /> Replace the contents of the drawer menu by a custom widget
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group" ng-if="form.drawer.use_custom_widget" ng-class="{error: _form.drawer.use_custom_widget.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Custom Widget</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <select ng-model="form.drawer.custom_widget" ng-change="updateCustomWidgetSettings(true, 'drawer')" class="form-control">
+                                        <option value=""></option>
+                                        <option ng-repeat="(id, widget) in configWidgets" value="{{id}}">{{id}}</option>
+                                        <option ng-repeat="(id, widget) in customwidgets" value="{{id}}">{{id}}</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div ng-if="form.drawer.use_custom_widget && form.drawer.custom_widget">
+                                <hr />
+                                <div ng-repeat="type in ['drawer']" ng-include="'app/menu/custom_widget_form.html'"></div>
+                            </div>
+
+                        </div>
+
+                        <div uib-accordion-group class="panel-default" heading="Dashboard header{{(form.header.use_custom_widget && form.header.custom_widget) ? ': ' + form.drawer.custom_widget : ''}}">
+
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.header.use_custom_widget.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Use a custom widget</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="vertical" ng-model="form.header.use_custom_widget" /> Replace the contents of the dashboard header by a custom widget
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group" ng-if="form.header.use_custom_widget" ng-class="{error: _form.header.use_custom_widget.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Custom Widget</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <select ng-model="form.header.custom_widget" ng-change="updateCustomWidgetSettings(true, 'header')" class="form-control">
+                                        <option value=""></option>
+                                        <option ng-repeat="(id, widget) in configWidgets" value="{{id}}">{{id}}</option>
+                                        <option ng-repeat="(id, widget) in customwidgets" value="{{id}}">{{id}}</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div ng-if="form.drawer.use_custom_widget && form.header.custom_widget">
+                                <hr />
+                                <div ng-repeat="type in ['header']" ng-include="'app/menu/custom_widget_form.html'"></div>
+                            </div>
+
+                        </div>
+
+                    </uib-accordion>
 
                 </uib-tab>
             </uib-tabset>

--- a/web/app/menu/menu.settings.tpl.html
+++ b/web/app/menu/menu.settings.tpl.html
@@ -221,7 +221,7 @@
 
                         </div>
 
-                        <div uib-accordion-group class="panel-default" heading="Dashboard header{{(form.header.use_custom_widget && form.header.custom_widget) ? ': ' + form.drawer.custom_widget : ''}}">
+                        <div uib-accordion-group class="panel-default" heading="Dashboard header{{(form.header.use_custom_widget && form.header.custom_widget) ? ': ' + form.header.custom_widget : ''}}">
 
                             <br />
                             <div class="form-group" ng-class="{error: _form.header.use_custom_widget.$error && _form.submitted}">
@@ -246,7 +246,7 @@
                                 </div>
                             </div>
 
-                            <div ng-if="form.drawer.use_custom_widget && form.header.custom_widget">
+                            <div ng-if="form.header.use_custom_widget && form.header.custom_widget">
                                 <hr />
                                 <div ng-repeat="type in ['header']" ng-include="'app/menu/custom_widget_form.html'"></div>
                             </div>

--- a/web/app/menu/menu.settings.tpl.html
+++ b/web/app/menu/menu.settings.tpl.html
@@ -2,7 +2,7 @@
     <div class="form-group" ng-repeat="setting in widgetsettings[type]">
         <label ng-if="setting.type !== 'heading'" class="control-label col-lg-3 col-md-3">{{setting.label || setting.id}}</label>
         <div class="col-lg-9 col-md-9" ng-switch="setting.type">
-            <h5 ng-if="setting.type === 'heading'">{{setting.label}}</h5>
+            <h4 ng-if="setting.type === 'heading'">{{setting.label}}</h4>
             <input ng-switch-when="string" type="text" ng-model="form[type].custom_widget_config[setting.id]" class="form-control">
             <input ng-switch-when="number" type="number" ng-model="form[type].custom_widget_config[setting.id]" class="form-control" step="any" style="width: 120px">
             <div ng-switch-when="checkbox" style="padding-top: 7px"><input type="checkbox" ng-model="form[type].custom_widget_config[setting.id]"> {{setting.description}}</div>


### PR DESCRIPTION
This allows the ability to set and configure a custom widget to display
instead of the default design for the side drawer dashboard menu entry,
and the dashboard header. Limited interactivity is recommended!

Signed-off-by: Yannick Schaus <habpanel@schaus.net>