### PR TITLE
Charts: Send `theme` parameter for `default` charts

### DIFF
--- a/web/app/widgets/chart/chart.widget.js
+++ b/web/app/widgets/chart/chart.widget.js
@@ -246,11 +246,14 @@
 
         vm.imageQueryString = function(val) {
             var ret = "";
+            var chartTheme = themeValueFilter(vm.widget.theme, 'chart-default-theme');
             if (vm.widget.isgroup)
                 ret = "groups=" + vm.widget.item;
             else
                 ret = "items=" + vm.widget.item;
-
+            if (chartTheme) {
+                ret += '&theme=' + chartTheme.replace(/"/g, '');
+            }
             return ret + "&period=" + vm.widget.period;
         }
 

--- a/web/assets/styles/themes/default.css
+++ b/web/assets/styles/themes/default.css
@@ -19,6 +19,7 @@
     --chart-stroke: #456;
     --chart-fill: #89a;
     --chart-tooltip: #123;
+    --chart-default-theme: "black";
     /* Color picker widget */
     --colorpicker-border: #3960ff;
     --colorpicker-stroke: #456;

--- a/web/assets/styles/themes/madras.css
+++ b/web/assets/styles/themes/madras.css
@@ -20,6 +20,7 @@
   --chart-stroke: #456;
   --chart-fill: #89a;
   --chart-tooltip: #fff;
+  --chart-default-theme: "bright";
   --colorpicker-border: #191716;
   --colorpicker-stroke: #456;
   --colorpicker-fill: #89a;

--- a/web/assets/styles/themes/material-dark.css
+++ b/web/assets/styles/themes/material-dark.css
@@ -19,6 +19,7 @@
     --chart-stroke: #456;
     --chart-fill: #89a;
     --chart-tooltip: #123;
+    --chart-default-theme: "dark";
     /* Color picker widget */
     --colorpicker-border: #3960ff;
     --colorpicker-stroke: #456;

--- a/web/assets/styles/themes/material.css
+++ b/web/assets/styles/themes/material.css
@@ -19,6 +19,7 @@
     --chart-stroke: #456;
     --chart-fill: #89a;
     --chart-tooltip: #fff;
+    --chart-default-theme: "white";
     /* Color picker widget */
     --colorpicker-border: #3960ff;
     --colorpicker-stroke: #456;

--- a/web/assets/styles/themes/orange-tree.css
+++ b/web/assets/styles/themes/orange-tree.css
@@ -21,6 +21,7 @@
   --chart-stroke: #456;
   --chart-fill: #89a;
   --chart-tooltip: #fff;
+  --chart-default-theme: "black";
   --colorpicker-border: #191716;
   --colorpicker-stroke: #456;
   --colorpicker-fill: #89a;

--- a/web/assets/styles/themes/paleblue.css
+++ b/web/assets/styles/themes/paleblue.css
@@ -18,6 +18,7 @@
     --chart-stroke: #456;
     --chart-fill: #89a;
     --chart-tooltip: #123;
+    --chart-default-theme: "black";
     /* Color picker widget */
     --colorpicker-border: #3960FF;
     --colorpicker-stroke: #456;

--- a/web/assets/styles/themes/translucent.css
+++ b/web/assets/styles/themes/translucent.css
@@ -19,6 +19,7 @@
     --chart-stroke: #456;
     --chart-fill: #89a;
     --chart-tooltip: #123;
+    --chart-default-theme: "black";
     /* Color picker widget */
     --colorpicker-border: #3960FF;
     --colorpicker-stroke: #456;


### PR DESCRIPTION
Take a matching chart theme for the current habpanel theme and send it to the ESH chart servlet.

----

The ESH `DefaultChartProvider` recently got a new feature to support different themes:
https://github.com/eclipse/smarthome/pull/4291

This change adds the `&theme=xxx` parameter to the servlet URL, based on the current habpanel theme.
