### PR TITLE
Make the background color of image widgets configurable

### DIFF
--- a/web/app/widgets/image/image.scss
+++ b/web/app/widgets/image/image.scss
@@ -1,5 +1,4 @@
 .image {
-    background: black;
     display: flex;
     border: 1px solid #456;
     border: 1px solid var(--image-border, #456);

--- a/web/app/widgets/image/image.settings.tpl.html
+++ b/web/app/widgets/image/image.settings.tpl.html
@@ -56,6 +56,12 @@
                     </div>
                 </div>
             </div>
+            <div class="form-group" ng-class="{error: _form.background.$error && _form.submitted}">
+                <label class="control-label col-lg-3 col-md-3">Background color</label>
+                <div class="col-lg-9 col-md-9">
+                    <div dab-model="form.background" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
+                </div>
+            </div>
         </div>
         <div class="modal-footer">
             <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>

--- a/web/app/widgets/image/image.tpl.html
+++ b/web/app/widgets/image/image.tpl.html
@@ -1,4 +1,4 @@
-<div class="box-content image">
+<div class="box-content image" ng-style="{ 'background-color': vm.background }">
     <div class="image-content">
         <img src="{{vm.url}}" />
     </div>

--- a/web/app/widgets/image/image.widget.js
+++ b/web/app/widgets/image/image.widget.js
@@ -74,6 +74,7 @@
             });
         }
 
+        vm.background = this.widget.background || 'rgb(0, 0, 0)';
     }
 
 
@@ -93,7 +94,8 @@
             image_source: widget.image_source || 'static',
             url         : widget.url,
             refresh     : widget.refresh,
-            intervaltype: widget.intervaltype || 'seconds'
+            intervaltype: widget.intervaltype || 'seconds',
+            background  : widget.background || 'rgb(0, 0, 0)'
         };
         if (widget.image_source === 'item-string') $scope.form.item_string = widget.item;
         if (widget.image_source === 'item-image') $scope.form.item_image = widget.item;


### PR DESCRIPTION
Made the background color of image widgets configurable (basically to support images with transparency). Therefore I would personally prefer 'transparent' as default background color but I have chosen black for backward compatibility.
...it would also be nice to have the border configurable/optional - maybe another pull request follows :)