### PR TITLE
Charts: Add "Show legend" option for "Default" charts

### DIFF
--- a/web/app/widgets/chart/chart.settings.tpl.html
+++ b/web/app/widgets/chart/chart.settings.tpl.html
@@ -56,6 +56,16 @@
                             </select>
                         </div>
                     </div>
+                    <div class="form-group" ng-class="{error: _form.showlegend.$error && _form.submitted}" ng-if="form.charttype=='default'">
+                        <label class="control-label col-lg-3 col-md-3">Show legend</label>
+                        <div class="col-lg-9 col-md-9">
+                            <select ng-model="form.showlegend" class="form-control">
+                                <option value="auto">Automatic</option>
+                                <option value="always">Always</option>
+                                <option value="never">Never</option>
+                            </select>
+                        </div>
+                    </div>
                 </uib-tab>
                     <!--<div class="form-group" ng-class="{error: _form.refresh.$error && _form.submitted}">
                         <label class="control-label col-lg-3 col-md-3">Resfresh interval</label>

--- a/web/app/widgets/chart/chart.widget.js
+++ b/web/app/widgets/chart/chart.widget.js
@@ -246,13 +246,29 @@
 
         vm.imageQueryString = function(val) {
             var ret = "";
-            var chartTheme = themeValueFilter(vm.widget.theme, 'chart-default-theme');
             if (vm.widget.isgroup)
                 ret = "groups=" + vm.widget.item;
             else
                 ret = "items=" + vm.widget.item;
+            // if chartTheme is given, append the theme parameter.
+            // empty theme parameter renders the default theme.
+            var chartTheme = themeValueFilter(vm.widget.theme, 'chart-default-theme');
             if (chartTheme) {
                 ret += '&theme=' + chartTheme.replace(/"/g, '');
+            }
+            // append legend parameter
+            if (vm.widget.showlegend) {
+                switch (vm.widget.showlegend) {
+                    case "auto":
+                        // do not append anything, as 'automatic' is the default
+                        break;
+                    case "always":
+                        ret += "&legend=true";
+                        break;
+                    case "never":
+                        ret += "&legend=false";
+                        break;
+                }
             }
             return ret + "&period=" + vm.widget.period;
         }
@@ -277,6 +293,7 @@
             charttype: widget.charttype,
             service: widget.service,
             period: widget.period,
+            showlegend: widget.showlegend,
             refresh: widget.refresh,
             axis: widget.axis || {y: {}, y2: {} },
             series: widget.series || [],
@@ -315,6 +332,9 @@
             } else {
                 if (!widget.axis.y2.enabled)
                     delete widget.axis.y2;
+            }
+            if (widget.charttype !== "default") {
+                delete widget.showlegend;
             }
 
             $modalInstance.close(widget);


### PR DESCRIPTION
The ESH DefaultChartProvider recently got a new feature to hide the legend:
eclipse/smarthome#4291

---

* Add the Option "Show legend" to the chart settings. Only shown if the "Default" chart is selected.
    - "automatic" -> let the chart provider decide (current behaviour: hide if there is only one chart series, show otherwise)
    - "always" -> force show
    - "never" -> force hide
* Send `legend=true/false` to the chart servlet, if "always" or "never" is choosen. If "automatic" is selected, do not send the paramater, as this triggers the automatic decision.

**Chart settings:**
![chart-settings](https://user-images.githubusercontent.com/21249127/31245808-c4331252-aa0b-11e7-9daf-d98ddef205e2.png)

**Setting `Show legend: Never` results in:**
![chart-legend-never](https://user-images.githubusercontent.com/21249127/31245821-d2bf67ee-aa0b-11e7-85db-d1e96c486887.png)

