### PR TITLE
Improve dashboard settings saving mechanism

### DIFF
--- a/web/app/menu/drawer.controller.js
+++ b/web/app/menu/drawer.controller.js
@@ -27,6 +27,10 @@
             return ($location.url() === '/view/' + encodeURI(name) || $location.url() === '/edit/' + encodeURI(name));
         }
 
+        $scope.isShown = function (dash) {
+            return (!dash.drawer || !dash.drawer.hide);
+        }
+
         activate();
 
         $scope.$on("refreshMenu", function (evt) {

--- a/web/app/menu/drawer.tpl.html
+++ b/web/app/menu/drawer.tpl.html
@@ -5,7 +5,7 @@
     <li ng-if="settings.drawer_heading_image" ng-click="goHome()" style="padding: 0">
         <img ng-src="{{settings.drawer_heading_image}}" />
     </li>
-    <li ng-repeat="dash in dashboards | orderBy:['row', 'col']" ng-class="{ active: isActive(dash.id) }" ng-click="goToDashboard(dash.id)">
+    <li ng-repeat="dash in dashboards | filter:isShown | orderBy:['row', 'col']" ng-class="{ active: isActive(dash.id) }" ng-click="goToDashboard(dash.id)">
         <widget-icon ng-if="dash.tile.iconset && dash.tile.icon && !dash.drawer.use_custom_widget" style="position:absolute; right: 20px" iconset="dash.tile.iconset" icon="dash.tile.icon" inline="true" size="24"></widget-icon>
         <span ng-if="!dash.drawer.use_custom_widget">{{dash.name}}</span>
         <div ng-if="dash.drawer.use_custom_widget" ng-click="vm.viewDashboard(dash)" class="card-title" style="cursor: pointer; height: 100%"

--- a/web/app/menu/menu.controller.js
+++ b/web/app/menu/menu.controller.js
@@ -125,10 +125,6 @@
                         return dashboard;
                     }
                 }
-            }).result.then(function (dashboards) {
-                var newdashboard = PersistenceService.getDashboard(dashboard.id);
-                var idx = vm.dashboards.indexOf(dashboard);
-                vm.dashboards[idx] = newdashboard; 
             });
         };
 
@@ -166,6 +162,7 @@
                 icon_size: dashboard.tile.icon_size,
                 icon_nolinebreak: dashboard.tile.icon_nolinebreak,
                 icon_replacestext: dashboard.tile.icon_replacestext,
+                title_color: dashboard.tile.title_color,
                 no_click_feedback: dashboard.tile.no_click_feedback,
                 use_custom_widget: dashboard.tile.use_custom_widget,
                 custom_widget: dashboard.tile.custom_widget,
@@ -234,10 +231,9 @@
             }
 
             PersistenceService.saveDashboards().then(function () {
-                $rootScope.dashboards = null;
-                PersistenceService.getDashboards().then (function (dashboards) {
-                    $modalInstance.close(dashboards);
-                });
+                $modalInstance.close();
+            }, function (err) {
+                alert('Error while saving dashboards:' + err);
             });
         };
 

--- a/web/app/menu/menu.controller.js
+++ b/web/app/menu/menu.controller.js
@@ -174,6 +174,7 @@
                 custom_widget_config: dashboard.tile.custom_widget_config || {}
             },
             drawer: {
+                hide: dashboard.drawer.hide,
                 use_custom_widget: dashboard.drawer.use_custom_widget,
                 custom_widget: dashboard.drawer.custom_widget,
                 custom_widget_config: dashboard.drawer.custom_widget_config || {}
@@ -225,7 +226,7 @@
                 delete dashboard.tile.custom_widget_dontwrap;
                 delete dashboard.tile.custom_widget_nobackground;
             }
-            if (!dashboard.drawer.use_custom_widget) {
+            if (!dashboard.drawer.use_custom_widget && !dashboard.drawer.hide) {
                 delete dashboard.drawer;
             }
             if (!dashboard.header.use_custom_widget) {

--- a/web/app/menu/menu.settings.tpl.html
+++ b/web/app/menu/menu.settings.tpl.html
@@ -136,6 +136,16 @@
                             <input name="name" type="number" ng-model="form.mobile_breakpoint" class="form-control" />
                         </div>
                     </div>
+                    <div class="form-group" ng-class="{error: _form.drawer.hide.$error && _form.submitted}">
+                        <label class="control-label col-lg-3 col-md-3">Hide in drawer</label>
+                        <div class="col-lg-9 col-md-9">
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="vertical" ng-model="form.drawer.hide" /> Don't show in the side drawer menu
+                                </label>
+                            </div>
+                        </div>
+                    </div>
                 </uib-tab>
                 <uib-tab heading="Custom widgets">
                     <br />


### PR DESCRIPTION
- Get rid of unnecessary logic;
- Add alert in case of error;
- Fix mIssing hydration of `tile.title_color` property in form;
- Also add experimental option to hide dashboard from side drawer menu (closes #238).

Signed-off-by: Yannick Schaus <habpanel@schaus.net>