### PR TITLE
[Enhancement] Feature/smarterbutton. Ability to navigate to a URL/Dashboard and mimic a Dummy

### DIFF
--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -23,7 +23,7 @@
                                     <select ng-model="form.action_type" class="form-control">
                                         <option value="command">Send a fixed command to an item</option>
                                         <option value="toggle">Alternate item between 2 states</option>
-                                        <option value="navigate">Navigate to another dashboard</option>
+                                        <option value="navigate">Navigate</option>
                                     </select>
                                 </div>
                             </div>
@@ -45,12 +45,57 @@
                                     <input name="command" type="text" ng-model="form.command_alt" class="form-control" />
                                 </div>
                             </div>
-                            <div ng-if="form.action_type === 'navigate'" class="form-group" ng-class="{error: _form.navigate_dashboard.$error && _form.submitted}">
-                                <label class="control-label col-lg-3 col-md-3">Dashboard</label>
-                                <div class="col-lg-9 col-md-9">
-                                    <select ng-model="form.navigate_dashboard" class="form-control" ng-options="dashboard.id as dashboard.name for dashboard in dashboards"></select>
+                            <section ng-if="form.action_type === 'navigate'">
+                                <div class="form-group" ng-class="{error: _form.navigate_dashboard.$error && _form.submitted}">
+                                    <label class="control-label col-lg-3 col-md-3">Navigation type</label>
+                                    <div class="col-lg-9 col-md-9">
+                                        <div>
+                                            <label class="radio-inline">
+                                                <input type="radio" ng-model="form.navigate_type" value="dashboard" name="navigate_type" /> Dashboard
+                                            </label>
+                                            <label class="radio-inline">
+                                                <input type="radio" ng-model="form.navigate_type" value="url" name="navigate_type" /> URL
+                                            </label>
+                                        </div>
+                                    </div>
                                 </div>
-                            </div>
+                                <div class="form-group" ng-if="form.navigate_type=='dashboard'" ng-class="{error: _form.navigate_dashboard.$error && _form.submitted}">
+                                    <label class="control-label col-lg-3 col-md-3">Dashboard</label>
+                                    <div class="col-lg-9 col-md-9">
+                                        <ui-select ng-required="true" ng-model="form.navigate_url" theme="selectize" title="Choose a HABPanel dashboard">
+                                            <ui-select-match placeholder="Search or select an HABPanel dashboard">{{$select.selected.name}}</ui-select-match>
+                                            <ui-select-choices repeat="dashboard.id as dashboard in dashboards | filter: $select.search">
+                                                <div>
+                                                    <span ng-bind-html="dashboard.name | highlight: $select.search">
+                                                </div>
+                                                <small ng-bind-html="dashboard.label | highlight: $select.search"></small>
+                                            </ui-select-choices>
+                                        </ui-select>
+                                    </div>
+                                </div>
+                                <section ng-if="form.navigate_type=='url'">
+                                    <div class="form-group">
+                                        <label class="control-label col-lg-3 col-md-3">URL</label>
+                                        <div class="col-lg-9 col-md-9">
+                                            <input name="navigate_url" ng-model="form.navigate_url" class="form-control" required />
+                                        </div>
+                                    </div>
+                                    <div class="form-group" ng-if="form.navigate_url && form.navigate_type=='url'" ng-class="{error: _form.navigate_target.$error && _form.submitted}">
+                                        <label class="control-label col-lg-3 col-md-3">Link Target</label>
+                                        <div class="col-lg-9 col-md-9">
+                                            <label class="radio-inline">
+                                                <input type="radio" ng-model="form.navigate_target" value="self" name="navigate_target" checked/> self
+                                            </label>
+                                            <label class="radio-inline">
+                                                <input type="radio" ng-model="form.navigate_target" value="new_tab" name="navigate_target" /> new tab
+                                            </label>
+                                            <label class="radio-inline">
+                                                <input type="radio" ng-model="form.navigate_target" value="new_window" name="navigate_target" /> new window
+                                            </label>
+                                        </div>
+                                    </div>
+                                </section>
+                            </section>
                         </uib-tab>
 
                         <uib-tab heading="Inactive">
@@ -59,14 +104,6 @@
                                 <label class="control-label col-xs-4">Font size</label>
                                 <div class="col-xs-4">
                                     <input name="font_size" ng-model="form.font_size" class="form-control" />
-                                </div>
-                                <div class="col-xs-4">
-                                    <!--<label class="control-label">
-                                    <input type="checkbox"  name="font_bold" ng-model="form.font_bold" />
-                                    <label for="font_bold"><i class="glyphicon glyphicon-bold"></i></label>
-                                    <input type="checkbox"  name="font_italic" ng-model="form.font_italic" />
-                                    <label for="font_italic"><i class="glyphicon glyphicon-italic"></i></label>
-                                </label>-->
                                 </div>
                             </div>
                             <div class="form-group" ng-class="{error: _form.background.$error && _form.submitted}">
@@ -93,14 +130,6 @@
                                 <div class="col-xs-4">
                                     <input name="font_size" disabled="disabled" ng-model="form.font_size" class="form-control" />
                                 </div>
-                                <div class="col-xs-4">
-                                    <!--<label class="control-label">
-                                <input type="checkbox"  name="font_bold_active" ng-model="form.font_bold_active" />
-                                <label for="font_bold_active"><i class="glyphicon glyphicon-bold"></i></label>
-                                <input type="checkbox"  name="font_italic_active" ng-model="form.font_italic_active" />
-                                <label for="font_italic_active"><i class="glyphicon glyphicon-italic"></i></label>
-                            </label>-->
-                                </div>
                             </div>
                             <div class="form-group" ng-class="{error: _form.background_active.$error && _form.submitted}">
                                 <label class="control-label col-lg-2 col-md-2">Background color</label>
@@ -118,8 +147,7 @@
                             </div>
                         </uib-tab>
 
-
-                        <uib-tab heading="Icons">
+                        <uib-tab heading="Display">
                             <br />
                             <div class="form-group" ng-class="{error: _form.backdrop_icon.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">Backdrop Icon</label>
@@ -152,16 +180,66 @@
                                             <input type="checkbox" name="vertical" ng-model="form.icon_replacestext" /> Icon replaces text
                                         </label>
                                     </div>
-
                                 </div>
                             </div>
+
+
+
+                            <div class="form-group" ng-class="{error: _form.show_item_value.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Show item value</label>
+                                <div class="col-lg-3 col-md-3">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="show_item_value" ng-model="form.show_item_value" /> Yes
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div ng-if="form.action_type === 'navigate' && form.show_item_value" class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">openHAB Item</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <item-picker ng-model="form.item"></item-picker>
+                                </div>
+                            </div>
+
+                            <section ng-if="form.show_item_value">
+                                <div class="form-group" ng-class="{error: _form.unit.$error && _form.submitted}">
+                                    <label class="control-label col-xs-3">Unit (suffix)</label>
+                                    <div class="col-xs-4">
+                                        <input name="col" ng-disabled="form.useserverformat" ng-model="form.unit" class="form-control" />
+                                    </div>
+                                </div>
+                                <div class="form-group" ng-class="{error: _form.format.$error && _form.submitted}">
+                                    <label class="control-label col-xs-3">Format</label>
+                                    <div class="col-xs-7">
+                                        <input name="col" ng-disabled="form.useserverformat" ng-model="form.format" class="form-control" />
+                                    </div>
+                                    <label class="control-label col-lg-3 col-md-3"></label>
+                                    <div class="col-lg-9 col-md-9">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="vertical" ng-model="form.useserverformat" /> Use server-provided format if available (openHAB 2)
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="form-group" ng-class="{error: _form.nolinebreak.$error && _form.submitted}">
+                                    <label class="control-label col-lg-3 col-md-3">Layout</label>
+                                    <div class="col-lg-9 col-md-9">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="vertical" ng-model="form.nolinebreak" /> Value right of label instead of below
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </section>
                         </uib-tab>
-
-
                     </uib-tabset>
-
                 </div>
-                <div class="col-xs-3" style="height: 80px">
+                <div class="col-xs-3" style="height: 80px" ng-if="form.action_type !== 'navigate'">
                     <div class="box">
                         <div class="box-content switch" ng-style="{ 'background-color': form.background, color: form.foreground }">
                             <div class="switch-content">
@@ -178,44 +256,6 @@
                     </div>
                 </div>
             </div>
-
-
-            <!--<div class="row">
-                <div class="col-lg-6 col-md-6">
-                    <div class="form-group" ng-class="{error: _form.sizeX.$error && _form.submitted}">
-                        <label class="control-label col-lg-6 col-md-6">Width</label>
-                        <div class="col-lg-6 col-md-6">
-                            <input name="sizeX" ng-model="form.sizeX" class="form-control" />
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-6 col-md-6">
-                    <div class="form-group">
-                        <label class="control-label col-lg-6 col-md-6">Height</label>
-                        <div class="col-lg-6 col-md-6">
-                            <input name="sizeY" ng-model="form.sizeY" class="form-control" />
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-lg-6 col-md-6">
-                    <div class="form-group" ng-class="{error: _form.sizeX.$error && _form.submitted}">
-                        <label class="control-label col-lg-6 col-md-6">Column</label>
-                        <div class="col-lg-6 col-md-6">
-                            <input name="col" ng-model="form.col" class="form-control" />
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-6 col-md-6">
-                    <div class="form-group">
-                        <label class="control-label col-lg-6 col-md-6">Row</label>
-                        <div class="col-lg-6 col-md-6">
-                            <input name="row" ng-model="form.row" class="form-control" />
-                        </div>
-                    </div>
-                </div>
-            </div>-->
         </div>
 
         <div class="modal-footer">
@@ -223,7 +263,7 @@
                 <i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
             <a ng-click="dismiss()" class="btn btn-default" tabindex="-1">
                 <i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
-            <button type="submit" class="btn btn-primary">
+            <button type="submit" class="btn btn-primary" ng-disabled="_form.$invalid">
                 <i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>
     </form>

--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -246,6 +246,16 @@
                             </div>
                         </div>
                     </div>
+                    <div ng-if="form.action_type=='navigate' && form.show_item_value">
+                        <div>
+                            <label class="control-label">Active value:</label>
+                            <input name="font_size" ng-model="form.navigate_item_active_value" class="form-control" />
+                        </div>
+                        <div>
+                            <label class="control-label">Inactive value:</label>
+                            <input name="font_size" ng-model="form.navigate_item_inactive_value" class="form-control" />
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -93,8 +93,9 @@
 
                         <uib-tab heading="Display">
                             <br />
+                            <h4>Label</h4>
                             <div class="form-group" ng-class="{error: _form.font_size.$error && _form.submitted}">
-                                <label class="control-label col-lg-3 col-md-3">Label font size</label>
+                                <label class="control-label col-lg-3 col-md-3">Font size</label>
                                 <div class="col-xs-4">
                                     <input name="font_size" ng-model="form.font_size" class="form-control" />
                                 </div>

--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -62,15 +62,7 @@
                                 <div class="form-group" ng-if="form.navigate_type=='dashboard'" ng-class="{error: _form.navigate_dashboard.$error && _form.submitted}">
                                     <label class="control-label col-lg-3 col-md-3">Dashboard</label>
                                     <div class="col-lg-9 col-md-9">
-                                        <ui-select ng-required="true" ng-model="form.navigate_url" theme="selectize" title="Choose a HABPanel dashboard">
-                                            <ui-select-match placeholder="Search or select an HABPanel dashboard">{{$select.selected.name}}</ui-select-match>
-                                            <ui-select-choices repeat="dashboard.id as dashboard in dashboards | filter: $select.search">
-                                                <div>
-                                                    <span ng-bind-html="dashboard.name | highlight: $select.search">
-                                                </div>
-                                                <small ng-bind-html="dashboard.label | highlight: $select.search"></small>
-                                            </ui-select-choices>
-                                        </ui-select>
+                                        <select ng-model="form.navigate_dashboard" class="form-control" ng-options="dashboard.id as dashboard.name for dashboard in dashboards"></select>
                                     </div>
                                 </div>
                                 <section ng-if="form.navigate_type=='url'">
@@ -81,16 +73,16 @@
                                         </div>
                                     </div>
                                     <div class="form-group" ng-if="form.navigate_url && form.navigate_type=='url'" ng-class="{error: _form.navigate_target.$error && _form.submitted}">
-                                        <label class="control-label col-lg-3 col-md-3">Link Target</label>
+                                        <label class="control-label col-lg-3 col-md-3">Open in</label>
                                         <div class="col-lg-9 col-md-9">
                                             <label class="radio-inline">
-                                                <input type="radio" ng-model="form.navigate_target" value="self" name="navigate_target" checked/> self
+                                                <input type="radio" ng-model="form.navigate_target" value="self" name="navigate_target" checked/> Current tab
                                             </label>
                                             <label class="radio-inline">
-                                                <input type="radio" ng-model="form.navigate_target" value="new_tab" name="navigate_target" /> new tab
+                                                <input type="radio" ng-model="form.navigate_target" value="new_tab" name="navigate_target" /> New tab
                                             </label>
                                             <label class="radio-inline">
-                                                <input type="radio" ng-model="form.navigate_target" value="new_window" name="navigate_target" /> new window
+                                                <input type="radio" ng-model="form.navigate_target" value="new_window" name="navigate_target" /> New window
                                             </label>
                                         </div>
                                     </div>
@@ -239,7 +231,7 @@
                         </uib-tab>
                     </uib-tabset>
                 </div>
-                <div class="col-xs-3" style="height: 80px" ng-if="form.action_type !== 'navigate'">
+                <div class="col-xs-3" style="height: 80px">
                     <div class="box">
                         <div class="box-content switch" ng-style="{ 'background-color': form.background, color: form.foreground }">
                             <div class="switch-content">

--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -90,57 +90,18 @@
                             </section>
                         </uib-tab>
 
-                        <uib-tab heading="Inactive">
+
+                        <uib-tab heading="Display">
                             <br />
                             <div class="form-group" ng-class="{error: _form.font_size.$error && _form.submitted}">
-                                <label class="control-label col-xs-4">Font size</label>
+                                <label class="control-label col-lg-3 col-md-3">Label font size</label>
                                 <div class="col-xs-4">
                                     <input name="font_size" ng-model="form.font_size" class="form-control" />
                                 </div>
                             </div>
-                            <div class="form-group" ng-class="{error: _form.background.$error && _form.submitted}">
-                                <label class="control-label col-lg-2 col-md-2">Background color</label>
-                                <div class="col-lg-4 col-md-4">
-                                    <div dab-model="form.background" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
-                                        show-grayscale="true"></div>
-                                </div>
-                            </div>
-                            <div class="form-group" ng-class="{error: _form.foreground.$error && _form.submitted}">
-                                <label class="control-label col-lg-2 col-md-2">Text color</label>
-                                <div class="col-lg-4 col-md-4">
-                                    <div dab-model="form.foreground" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
-                                        show-grayscale="true"></div>
-                                </div>
-                            </div>
-                        </uib-tab>
 
-
-                        <uib-tab heading="Active">
                             <br />
-                            <div class="form-group" ng-class="{error: _form.font_size.$error && _form.submitted}">
-                                <label class="control-label col-xs-4">Font size</label>
-                                <div class="col-xs-4">
-                                    <input name="font_size" disabled="disabled" ng-model="form.font_size" class="form-control" />
-                                </div>
-                            </div>
-                            <div class="form-group" ng-class="{error: _form.background_active.$error && _form.submitted}">
-                                <label class="control-label col-lg-2 col-md-2">Background color</label>
-                                <div class="col-lg-4 col-md-4">
-                                    <div dab-model="form.background_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
-                                        show-grayscale="true"></div>
-                                </div>
-                            </div>
-                            <div class="form-group" ng-class="{error: _form.foreground_active.$error && _form.submitted}">
-                                <label class="control-label col-lg-2 col-md-2">Text color</label>
-                                <div class="col-lg-4 col-md-4">
-                                    <div dab-model="form.foreground_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
-                                        show-grayscale="true"></div>
-                                </div>
-                            </div>
-                        </uib-tab>
-
-                        <uib-tab heading="Display">
-                            <br />
+                            <h4>Icons</h4>
                             <div class="form-group" ng-class="{error: _form.backdrop_icon.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">Backdrop Icon</label>
                                 <div class="col-lg-9 col-md-9">
@@ -175,14 +136,16 @@
                                 </div>
                             </div>
 
-
-
+                            <br />
+                            <h4>Value</h4>
                             <div class="form-group" ng-class="{error: _form.show_item_value.$error && _form.submitted}">
-                                <label class="control-label col-lg-3 col-md-3">Show item value</label>
-                                <div class="col-lg-3 col-md-3">
+                                <label class="control-label col-lg-3 col-md-3">&nbsp;</label>
+                                <div class="col-lg-9 col-md-9">
                                     <div class="checkbox">
                                         <label>
-                                            <input type="checkbox" name="show_item_value" ng-model="form.show_item_value" /> Yes
+                                            <input type="checkbox" name="show_item_value" ng-model="form.show_item_value" />
+                                            <span ng-if="form.action_type !== 'navigate'">Show the item's state value</span>
+                                            <span ng-if="form.action_type === 'navigate'">Show an item's state value</span>
                                         </label>
                                     </div>
                                 </div>
@@ -194,66 +157,124 @@
                                     <item-picker ng-model="form.item"></item-picker>
                                 </div>
                             </div>
+                            <div ng-if="form.action_type === 'navigate' && form.show_item_value" class="form-group" ng-class="{error: _form.command.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Active state</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <input name="command" type="text" ng-model="form.navigate_active_state" class="form-control" />
+                                </div>
+                            </div>
 
                             <section ng-if="form.show_item_value">
-                                <div class="form-group" ng-class="{error: _form.unit.$error && _form.submitted}">
+                                <div class="form-group" ng-class="{error: _form.font_size.$error && _form.submitted}">
+                                    <label class="control-label col-xs-3">Font size</label>
+                                    <div class="col-xs-4">
+                                        <input name="font_size" ng-model="form.value_font_size" class="form-control" />
+                                    </div>
+                                </div>
+                                <div class="form-group" ng-class="{error: _form.value_unit.$error && _form.submitted}">
                                     <label class="control-label col-xs-3">Unit (suffix)</label>
                                     <div class="col-xs-4">
-                                        <input name="col" ng-disabled="form.useserverformat" ng-model="form.unit" class="form-control" />
+                                        <input name="col" ng-disabled="form.value_useserverformat" ng-model="form.value_unit" class="form-control" />
                                     </div>
                                 </div>
                                 <div class="form-group" ng-class="{error: _form.format.$error && _form.submitted}">
                                     <label class="control-label col-xs-3">Format</label>
                                     <div class="col-xs-7">
-                                        <input name="col" ng-disabled="form.useserverformat" ng-model="form.format" class="form-control" />
+                                        <input name="col" ng-disabled="form.value_useserverformat" ng-model="form.value_format" class="form-control" />
                                     </div>
                                     <label class="control-label col-lg-3 col-md-3"></label>
                                     <div class="col-lg-9 col-md-9">
                                         <div class="checkbox">
                                             <label>
-                                                <input type="checkbox" name="vertical" ng-model="form.useserverformat" /> Use server-provided format if available (openHAB 2)
+                                                <input type="checkbox" name="vertical" ng-model="form.value_useserverformat" /> Use server-provided format if available
                                             </label>
                                         </div>
                                     </div>
                                 </div>
 
-                                <div class="form-group" ng-class="{error: _form.nolinebreak.$error && _form.submitted}">
+                                <div class="form-group" ng-class="{error: _form.value_nolinebreak.$error && _form.submitted}">
                                     <label class="control-label col-lg-3 col-md-3">Layout</label>
                                     <div class="col-lg-9 col-md-9">
                                         <div class="checkbox">
                                             <label>
-                                                <input type="checkbox" name="vertical" ng-model="form.nolinebreak" /> Value right of label instead of below
+                                                <input type="checkbox" name="vertical" ng-model="form.value_nolinebreak" /> Value right of label instead of below
                                             </label>
                                         </div>
                                     </div>
                                 </div>
                             </section>
                         </uib-tab>
+
+
+                        <uib-tab heading="{{(form.action_type !== 'navigate' || form.show_item_value) ? 'Inactive' : 'Colors'}}">
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.background.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Background color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.background" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
+                            </div>
+                            <div class="form-group" ng-class="{error: _form.foreground.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Label color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.foreground" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
+                            </div>
+                            <div class="form-group" ng-if="form.show_item_value" ng-class="{error: _form.value_color.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Value color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.value_color" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
+                            </div>
+                        </uib-tab>
+
+
+                        <uib-tab heading="Active" ng-if="form.action_type !== 'navigate' || form.show_item_value">
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.background_active.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Background color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.background_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
+                            </div>
+                            <div class="form-group" ng-class="{error: _form.foreground_active.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Label color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.foreground_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
+                            </div>
+                            <div class="form-group" ng-if="form.show_item_value" ng-class="{error: _form.value_color_active.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Value color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.value_color_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
+                            </div>
+                        </uib-tab>
+
                     </uib-tabset>
                 </div>
-                <div class="col-xs-3" style="height: 80px">
-                    <div class="box">
-                        <div class="box-content switch" ng-style="{ 'background-color': form.background, color: form.foreground }">
+                <div class="col-xs-3">
+                    <div class="box" style="overflow: hidden;">
+                        <div class="box-content switch" ng-style="{ 'background-color': form.background, color: form.foreground, padding: '20px' }">
                             <div class="switch-content">
-                                <span ng-style="{ 'font-size': form.font_size + 'pt' }">Inactive</span>
+                                <span ng-if="form.action_type !== 'navigate' || form.show_item_value" ng-style="{ 'font-size': form.font_size + 'pt' }">Inactive</span>
+                                <span ng-if="form.action_type === 'navigate' && !form.show_item_value" ng-style="{ 'font-size': form.font_size + 'pt' }">Label</span>
+                                <div ng-if="form.show_item_value" class="value" ng-style="{ 'color': form.value_color, 'font-size': form.value_font_size + 'pt' }">State</div>
                             </div>
                         </div>
                     </div>
-                    <div class="box">
-                        <div class="box-content switch" ng-style="{ 'background-color': form.background_active, color: form.foreground_active }">
+                    <div class="box" ng-if="form.action_type !== 'navigate' || form.show_item_value" style="overflow: hidden;">
+                        <div class="box-content switch" ng-style="{ 'background-color': form.background_active, color: form.foreground_active, padding: '20px' }">
                             <div class="switch-content">
                                 <span ng-style="{ 'font-size': form.font_size + 'pt' }">Active</span>
+                                <div ng-if="form.show_item_value" class="value" ng-style="{ 'color': form.value_color_active, 'font-size': form.value_font_size + 'pt' }">State</div>
                             </div>
-                        </div>
-                    </div>
-                    <div ng-if="form.action_type=='navigate' && form.show_item_value">
-                        <div>
-                            <label class="control-label">Active value:</label>
-                            <input name="font_size" ng-model="form.navigate_item_active_value" class="form-control" />
-                        </div>
-                        <div>
-                            <label class="control-label">Inactive value:</label>
-                            <input name="font_size" ng-model="form.navigate_item_inactive_value" class="form-control" />
                         </div>
                     </div>
                 </div>

--- a/web/app/widgets/button/button.settings.tpl.html
+++ b/web/app/widgets/button/button.settings.tpl.html
@@ -7,61 +7,61 @@
 
         <div class="modal-body">
             <div class="form-group">
-                <div class="col-xs-9"> 
-                <uib-tabset>
-                    <uib-tab heading="General">
-                      <br />
-                      <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
-                          <label class="control-label col-lg-3 col-md-3">Name</label>
-                          <div class="col-lg-9 col-md-9">
-                              <input name="name" type="text" ng-model="form.name" class="form-control" />
-                          </div>
-                      </div>
-                      <div class="form-group" ng-class="{error: _form.action_type.$error && _form.submitted}">
-                          <label class="control-label col-lg-3 col-md-3">Action type</label>
-                          <div class="col-lg-9 col-md-9">
-                              <select ng-model="form.action_type" class="form-control">
-                                  <option value="command">Send a fixed command to an item</option>
-                                  <option value="toggle">Alternate item between 2 states</option>
-                                  <option value="navigate">Navigate to another dashboard</option>
-                              </select>
-                          </div>
-                      </div>
-                      <div ng-if="form.action_type !== 'navigate'" class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
-                          <label class="control-label col-lg-3 col-md-3">openHAB Item</label>
-                          <div class="col-lg-9 col-md-9">
-                                <item-picker ng-model="form.item"></item-picker>
-                          </div>
-                      </div>
-                      <div ng-if="form.action_type !== 'navigate'" class="form-group" ng-class="{error: _form.command.$error && _form.submitted}">
-                          <label class="control-label col-lg-3 col-md-3">Command value</label>
-                          <div class="col-lg-9 col-md-9">
-                              <input name="command" type="text" ng-model="form.command" class="form-control" />
-                          </div>
-                      </div>
-                      <div ng-if="form.action_type === 'toggle'" class="form-group" ng-class="{error: _form.command_alt.$error && _form.submitted}">
-                          <label class="control-label col-lg-3 col-md-3">Alternate command value</label>
-                          <div class="col-lg-9 col-md-9">
-                              <input name="command" type="text" ng-model="form.command_alt" class="form-control" />
-                          </div>
-                      </div>
-                      <div ng-if="form.action_type === 'navigate'" class="form-group" ng-class="{error: _form.navigate_dashboard.$error && _form.submitted}">
-                          <label class="control-label col-lg-3 col-md-3">Dashboard</label>
-                          <div class="col-lg-9 col-md-9">
-                              <select ng-model="form.navigate_dashboard" class="form-control" ng-options="dashboard.id as dashboard.name for dashboard in dashboards"></select>
-                          </div>
-                      </div>
-                    </uib-tab>
+                <div class="col-xs-9">
+                    <uib-tabset>
+                        <uib-tab heading="General">
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Name</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                                </div>
+                            </div>
+                            <div class="form-group" ng-class="{error: _form.action_type.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Action type</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <select ng-model="form.action_type" class="form-control">
+                                        <option value="command">Send a fixed command to an item</option>
+                                        <option value="toggle">Alternate item between 2 states</option>
+                                        <option value="navigate">Navigate to another dashboard</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div ng-if="form.action_type !== 'navigate'" class="form-group" ng-class="{error: _form.item.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">openHAB Item</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <item-picker ng-model="form.item"></item-picker>
+                                </div>
+                            </div>
+                            <div ng-if="form.action_type !== 'navigate'" class="form-group" ng-class="{error: _form.command.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Command value</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <input name="command" type="text" ng-model="form.command" class="form-control" />
+                                </div>
+                            </div>
+                            <div ng-if="form.action_type === 'toggle'" class="form-group" ng-class="{error: _form.command_alt.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Alternate command value</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <input name="command" type="text" ng-model="form.command_alt" class="form-control" />
+                                </div>
+                            </div>
+                            <div ng-if="form.action_type === 'navigate'" class="form-group" ng-class="{error: _form.navigate_dashboard.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Dashboard</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <select ng-model="form.navigate_dashboard" class="form-control" ng-options="dashboard.id as dashboard.name for dashboard in dashboards"></select>
+                                </div>
+                            </div>
+                        </uib-tab>
 
-                    <uib-tab heading="Inactive">
-                    <br />
+                        <uib-tab heading="Inactive">
+                            <br />
                             <div class="form-group" ng-class="{error: _form.font_size.$error && _form.submitted}">
                                 <label class="control-label col-xs-4">Font size</label>
                                 <div class="col-xs-4">
                                     <input name="font_size" ng-model="form.font_size" class="form-control" />
                                 </div>
                                 <div class="col-xs-4">
-                                <!--<label class="control-label">
+                                    <!--<label class="control-label">
                                     <input type="checkbox"  name="font_bold" ng-model="form.font_bold" />
                                     <label for="font_bold"><i class="glyphicon glyphicon-bold"></i></label>
                                     <input type="checkbox"  name="font_italic" ng-model="form.font_italic" />
@@ -69,93 +69,97 @@
                                 </label>-->
                                 </div>
                             </div>
-                        <div class="form-group" ng-class="{error: _form.background.$error && _form.submitted}">
-                            <label class="control-label col-lg-2 col-md-2">Background color</label>
-                            <div class="col-lg-4 col-md-4">
-                                <div dab-model="form.background" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
+                            <div class="form-group" ng-class="{error: _form.background.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Background color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.background" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="form-group" ng-class="{error: _form.foreground.$error && _form.submitted}">
-                            <label class="control-label col-lg-2 col-md-2">Text color</label>
-                            <div class="col-lg-4 col-md-4">
-                                <div dab-model="form.foreground" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
+                            <div class="form-group" ng-class="{error: _form.foreground.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Text color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.foreground" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
                             </div>
-                        </div>
-                    </uib-tab>
+                        </uib-tab>
 
 
-                    <uib-tab heading="Active">
-                    <br />
-                        <div class="form-group" ng-class="{error: _form.font_size.$error && _form.submitted}">
-                            <label class="control-label col-xs-4">Font size</label>
-                            <div class="col-xs-4">
-                                <input name="font_size" disabled="disabled" ng-model="form.font_size" class="form-control" />
-                            </div>
-                            <div class="col-xs-4">
-                            <!--<label class="control-label">
+                        <uib-tab heading="Active">
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.font_size.$error && _form.submitted}">
+                                <label class="control-label col-xs-4">Font size</label>
+                                <div class="col-xs-4">
+                                    <input name="font_size" disabled="disabled" ng-model="form.font_size" class="form-control" />
+                                </div>
+                                <div class="col-xs-4">
+                                    <!--<label class="control-label">
                                 <input type="checkbox"  name="font_bold_active" ng-model="form.font_bold_active" />
                                 <label for="font_bold_active"><i class="glyphicon glyphicon-bold"></i></label>
                                 <input type="checkbox"  name="font_italic_active" ng-model="form.font_italic_active" />
                                 <label for="font_italic_active"><i class="glyphicon glyphicon-italic"></i></label>
                             </label>-->
-                            </div>
-                        </div>
-                        <div class="form-group" ng-class="{error: _form.background_active.$error && _form.submitted}">
-                            <label class="control-label col-lg-2 col-md-2">Background color</label>
-                            <div class="col-lg-4 col-md-4">
-                                <div dab-model="form.background_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
-                            </div>
-                        </div>
-                        <div class="form-group" ng-class="{error: _form.foreground_active.$error && _form.submitted}">
-                            <label class="control-label col-lg-2 col-md-2">Text color</label>
-                            <div class="col-lg-4 col-md-4">
-                                <div dab-model="form.foreground_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
-                            </div>
-                        </div>
-                    </uib-tab>
-
-
-                    <uib-tab heading="Icons">
-                        <br />
-                        <div class="form-group" ng-class="{error: _form.backdrop_icon.$error && _form.submitted}">
-                            <label class="control-label col-lg-3 col-md-3">Backdrop Icon</label>
-                            <div class="col-lg-9 col-md-9">
-                                <icon-picker iconset="form.backdrop_iconset" icon="form.backdrop_icon"></icon-picker>
-                                <div ng-if="form.backdrop_icon" class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="vertical" ng-model="form.backdrop_center" /> Center backdrop horizontally
-                                    </label>
                                 </div>
                             </div>
-                        </div>
-
-                        <div class="form-group" ng-class="{error: _form.icon.$error && _form.submitted}">
-                            <label class="control-label col-lg-3 col-md-3">Icon</label>
-                            <div class="col-lg-9 col-md-9">
-                                <icon-picker iconset="form.iconset" icon="form.icon"></icon-picker>
-                                <div class="col-xs-6 input-group" ng-if="form.icon">
-                                    <div class="input-group-addon">Size</div>
-                                    <input name="icon_size" ng-model="form.icon_size" class="form-control" />
-                                    <div class="input-group-addon">px</div>
+                            <div class="form-group" ng-class="{error: _form.background_active.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Background color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.background_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
                                 </div>
-                                <div ng-if="form.icon" class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="vertical" ng-model="form.icon_nolinebreak" /> Icon left of label instead of below
-                                    </label>
-                                </div>
-                                <div ng-if="form.icon" class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="vertical" ng-model="form.icon_replacestext" /> Icon replaces text
-                                    </label>
-                                </div>
-
                             </div>
-                        </div>
-                    </uib-tab>
+                            <div class="form-group" ng-class="{error: _form.foreground_active.$error && _form.submitted}">
+                                <label class="control-label col-lg-2 col-md-2">Text color</label>
+                                <div class="col-lg-4 col-md-4">
+                                    <div dab-model="form.foreground_active" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                                        show-grayscale="true"></div>
+                                </div>
+                            </div>
+                        </uib-tab>
 
 
-                </uib-tabset>
-                
+                        <uib-tab heading="Icons">
+                            <br />
+                            <div class="form-group" ng-class="{error: _form.backdrop_icon.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Backdrop Icon</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <icon-picker iconset="form.backdrop_iconset" icon="form.backdrop_icon"></icon-picker>
+                                    <div ng-if="form.backdrop_icon" class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="vertical" ng-model="form.backdrop_center" /> Center backdrop horizontally
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group" ng-class="{error: _form.icon.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Icon</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <icon-picker iconset="form.iconset" icon="form.icon"></icon-picker>
+                                    <div class="col-xs-6 input-group" ng-if="form.icon">
+                                        <div class="input-group-addon">Size</div>
+                                        <input name="icon_size" ng-model="form.icon_size" class="form-control" />
+                                        <div class="input-group-addon">px</div>
+                                    </div>
+                                    <div ng-if="form.icon" class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="vertical" ng-model="form.icon_nolinebreak" /> Icon left of label instead of below
+                                        </label>
+                                    </div>
+                                    <div ng-if="form.icon" class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="vertical" ng-model="form.icon_replacestext" /> Icon replaces text
+                                        </label>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </uib-tab>
+
+
+                    </uib-tabset>
+
                 </div>
                 <div class="col-xs-3" style="height: 80px">
                     <div class="box">
@@ -175,7 +179,7 @@
                 </div>
             </div>
 
-            
+
             <!--<div class="row">
                 <div class="col-lg-6 col-md-6">
                     <div class="form-group" ng-class="{error: _form.sizeX.$error && _form.submitted}">
@@ -215,9 +219,12 @@
         </div>
 
         <div class="modal-footer">
-            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
-            <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
-            <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
+            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1">
+                <i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-click="dismiss()" class="btn btn-default" tabindex="-1">
+                <i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
+            <button type="submit" class="btn btn-primary">
+                <i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
         </div>
     </form>
 </div>

--- a/web/app/widgets/button/button.tpl.html
+++ b/web/app/widgets/button/button.tpl.html
@@ -1,12 +1,16 @@
-<div class="box-content switch" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
-    <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon"
-        center="vm.widget.backdrop_center"></widget-icon>
+<style>
+    .button-dummy .box-content.dummy {
+        background-color: {{vm.background}};
+        color: {{vm.foreground}};
+    }
+</style>
+<widget-dummy class="button-dummy" ng-if="vm.widget.show_item_value" ng-model="vm.widget" ng-click="vm.sendCommand()"></widget-dummy>
+<div ng-if="!vm.widget.show_item_value" class="box-content switch" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
+    <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon" center="vm.widget.backdrop_center"></widget-icon>
     <div class="switch-content">
-        <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset"
-            icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
+        <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
         <!--<span ng-if="!vm.widget.nolinebreak">{{vm.widget.name}}</span>-->
-        <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset"
-            icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
+        <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
         <!--<br ng-if="!vm.widget.nolinebreak" />-->
         <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'font-size': vm.font_size + 'pt' }">{{vm.ngModel.name}}</span>
     </div>

--- a/web/app/widgets/button/button.tpl.html
+++ b/web/app/widgets/button/button.tpl.html
@@ -1,24 +1,20 @@
-<div class="box-content dummy" ng-if="vm.widget.show_item_value" ng-click="vm.sendCommand()" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
+<div class="box-content switch" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
     <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon" center="vm.widget.backdrop_center"></widget-icon>
-    <div class="dummy-content" ng-if="vm.widget.nolinebreak">
-        <span class="pull-left">{{vm.widget.name}}</span>
-    </div>
-    <div class="dummy-content">
-        <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.state"></widget-icon>
-        <span ng-if="!vm.widget.nolinebreak">{{vm.widget.name}}</span>
-        <br ng-if="!vm.widget.nolinebreak" />
-        <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.state"></widget-icon>
-        <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'font-size': vm.widget.font_size + 'pt' }" ng-class="{ 'dummy-value-right': vm.widget.nolinebreak }" class="value">{{vm.value}}<small ng-if="vm.widget.unit">{{vm.widget.unit}}</small></span>
-    </div>
-</div>
 
-<div ng-if="!vm.widget.show_item_value" class="box-content switch" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
-    <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon" center="vm.widget.backdrop_center"></widget-icon>
-    <div class="switch-content">
+    <div class="dummy-content" ng-if="vm.widget.value_nolinebreak && vm.widget.show_item_value">
+        <span class="pull-left" ng-style="{ 'font-size': vm.font_size + 'pt' }">{{vm.widget.name}}</span>
+    </div>
+    <div class="dummy-content" ng-if="vm.widget.show_item_value">
+        <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.state"></widget-icon>
+        <span ng-if="!vm.widget.value_nolinebreak" ng-style="{ 'color': vm.foreground, 'font-size': vm.font_size + 'pt' }">{{vm.widget.name}}</span>
+        <br ng-if="!vm.widget.value_nolinebreak" />
+        <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.state"></widget-icon>
+        <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'color': vm.value_color, 'font-size': vm.widget.value_font_size + 'pt' }" ng-class="{ 'dummy-value-right': vm.widget.value_nolinebreak }" class="value">{{vm.value}}<small ng-if="vm.widget.value_unit">{{vm.widget.value_unit}}</small></span>
+    </div>
+
+    <div class="switch-content" ng-if="!vm.widget.show_item_value">
         <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
-        <!--<span ng-if="!vm.widget.nolinebreak">{{vm.widget.name}}</span>-->
         <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
-        <!--<br ng-if="!vm.widget.nolinebreak" />-->
         <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'font-size': vm.font_size + 'pt' }">{{vm.ngModel.name}}</span>
     </div>
 </div>

--- a/web/app/widgets/button/button.tpl.html
+++ b/web/app/widgets/button/button.tpl.html
@@ -1,9 +1,12 @@
 <div class="box-content switch" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
-    <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon" center="vm.widget.backdrop_center"></widget-icon>
+    <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon"
+        center="vm.widget.backdrop_center"></widget-icon>
     <div class="switch-content">
-        <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
+        <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset"
+            icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
         <!--<span ng-if="!vm.widget.nolinebreak">{{vm.widget.name}}</span>-->
-        <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
+        <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset"
+            icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.value"></widget-icon>
         <!--<br ng-if="!vm.widget.nolinebreak" />-->
         <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'font-size': vm.font_size + 'pt' }">{{vm.ngModel.name}}</span>
     </div>

--- a/web/app/widgets/button/button.tpl.html
+++ b/web/app/widgets/button/button.tpl.html
@@ -1,10 +1,17 @@
-<style>
-    .button-dummy .box-content.dummy {
-        background-color: {{vm.background}};
-        color: {{vm.foreground}};
-    }
-</style>
-<widget-dummy class="button-dummy" ng-if="vm.widget.show_item_value" ng-model="vm.widget" ng-click="vm.sendCommand()"></widget-dummy>
+<div class="box-content dummy" ng-if="vm.widget.show_item_value" ng-click="vm.sendCommand()" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
+    <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon" center="vm.widget.backdrop_center"></widget-icon>
+    <div class="dummy-content" ng-if="vm.widget.nolinebreak">
+        <span class="pull-left">{{vm.widget.name}}</span>
+    </div>
+    <div class="dummy-content">
+        <widget-icon ng-if="vm.widget.icon && vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.state"></widget-icon>
+        <span ng-if="!vm.widget.nolinebreak">{{vm.widget.name}}</span>
+        <br ng-if="!vm.widget.nolinebreak" />
+        <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.state"></widget-icon>
+        <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'font-size': vm.widget.font_size + 'pt' }" ng-class="{ 'dummy-value-right': vm.widget.nolinebreak }" class="value">{{vm.value}}<small ng-if="vm.widget.unit">{{vm.widget.unit}}</small></span>
+    </div>
+</div>
+
 <div ng-if="!vm.widget.show_item_value" class="box-content switch" ng-style="{ 'background-color': vm.background, color: vm.foreground }" ng-click="vm.sendCommand()">
     <widget-icon ng-if="vm.widget.backdrop_icon" backdrop="true" iconset="vm.widget.backdrop_iconset" icon="vm.widget.backdrop_icon" center="vm.widget.backdrop_center"></widget-icon>
     <div class="switch-content">

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -1,11 +1,11 @@
-(function() {
+(function () {
     'use strict';
 
     angular
         .module('app.widgets')
         .directive('widgetButton', widgetButton)
         .controller('WidgetSettingsCtrl-button', WidgetSettingsCtrlButton)
-        .config(function (WidgetsProvider) { 
+        .config(function (WidgetsProvider) {
             WidgetsProvider.$get().registerType({
                 type: 'button',
                 displayName: 'Button',
@@ -32,16 +32,16 @@
             }
         };
         return directive;
-        
+
         function link(scope, element, attrs) {
             element[0].parentElement.parentElement.className += " activefeedback";
         }
     }
     ButtonController.$inject = ['$rootScope', '$scope', '$location', 'OHService'];
-    function ButtonController ($rootScope, $scope, $location, OHService) {
+    function ButtonController($rootScope, $scope, $location, OHService) {
         var vm = this;
         this.widget = this.ngModel;
-        
+
         vm.background = this.widget.background;
         vm.foreground = this.widget.foreground;
         vm.font_size = this.widget.font_size;
@@ -111,7 +111,7 @@
             foreground_active: widget.foreground_active,
             backdrop_iconset: widget.backdrop_iconset,
             backdrop_icon: widget.backdrop_icon,
-            backdrop_center : widget.backdrop_center,
+            backdrop_center: widget.backdrop_center,
             iconset: widget.iconset,
             icon: widget.icon,
             icon_size: widget.icon_size,
@@ -119,16 +119,16 @@
             icon_replacestext: widget.icon_replacestext
         };
 
-        $scope.dismiss = function() {
+        $scope.dismiss = function () {
             $modalInstance.dismiss();
         };
 
-        $scope.remove = function() {
+        $scope.remove = function () {
             $scope.dashboard.widgets.splice($scope.dashboard.widgets.indexOf(widget), 1);
             $modalInstance.close();
         };
 
-        $scope.submit = function() {
+        $scope.submit = function () {
             angular.extend(widget, $scope.form);
             switch (widget.action_type) {
                 case "navigate":

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -37,8 +37,8 @@
             element[0].parentElement.parentElement.className += " activefeedback";
         }
     }
-    ButtonController.$inject = ['$rootScope', '$scope', '$location', 'OHService', '$window'];
-    function ButtonController($rootScope, $scope, $location, OHService, $window) {
+    ButtonController.$inject = ['$rootScope', '$scope', '$location', 'OHService', '$window', 'themeValueFilter'];
+    function ButtonController($rootScope, $scope, $location, OHService, $window, themeValueFilter) {
         var vm = this;
         this.widget = this.ngModel;
 
@@ -49,12 +49,18 @@
         function updateValue() {
             vm.value = OHService.getItem(vm.widget.item).state;
             if (vm.value === vm.widget.command
-                || (vm.widget.action_type === 'navigate' && vm.widget.show_item_value && vm.value == vm.widget.navigate_item_active_value)) {
+                || (vm.widget.action_type === 'navigate' && vm.widget.show_item_value && vm.value == vm.widget.navigate_active_state)) {
                 vm.background = vm.widget.background_active;
                 vm.foreground = vm.widget.foreground_active;
+                if (vm.widget.show_item_value) {
+                    vm.value_color = themeValueFilter(vm.widget.value_color_active, 'primary-color');
+                }
             } else {
                 vm.background = vm.widget.background;
                 vm.foreground = vm.widget.foreground;
+                if (vm.widget.show_item_value) {
+                    vm.value_color = themeValueFilter(vm.widget.value_color, 'primary-color');
+                }
             }
         }
 
@@ -134,9 +140,11 @@
             command_alt: widget.command_alt,
             background: widget.background,
             foreground: widget.foreground,
+            value_color: widget.value_color,
             font_size: widget.font_size,
             background_active: widget.background_active,
             foreground_active: widget.foreground_active,
+            value_color_active: widget.value_color_active,
             backdrop_iconset: widget.backdrop_iconset,
             backdrop_icon: widget.backdrop_icon,
             backdrop_center: widget.backdrop_center,
@@ -145,13 +153,17 @@
             icon_size: widget.icon_size,
             icon_nolinebreak: widget.icon_nolinebreak,
             icon_replacestext: widget.icon_replacestext,
-            show_item_value: widget.show_item_value || false,
             navigate_type: (widget.navigate_url) ? 'url' : 'dashboard',
             navigate_url: widget.navigate_url,
             navigate_dashboard: widget.navigate_dashboard,
             navigate_target: widget.navigate_target || 'self',
-            navigate_item_active_value: widget.navigate_item_active_value,
-            navigate_item_inactive_value: widget.navigate_item_inactive_value
+            navigate_active_state: widget.navigate_active_state,
+            show_item_value: widget.show_item_value,
+            value_unit: widget.value_unit,
+            value_font_size: widget.value_font_size,
+            value_format: widget.value_format,
+            value_useserverformat: widget.value_useserverformat,
+            value_nolinebreak: widget.value_nolinebreak
         };
 
         $scope.dismiss = function () {
@@ -179,8 +191,7 @@
 
                     if (!$scope.form.show_item_value) {
                         delete widget.item;
-                        delete widget.navigate_item_active_value;
-                        delete widget.navigate_item_inactive_value;
+                        delete widget.navigate_active_state;
                     }
 
                     break;
@@ -190,8 +201,7 @@
                     delete widget.navigate_dashboard;
                     delete widget.navigate_type;
                     delete widget.navigate_target;
-                    delete widget.navigate_item_active_value;
-                    delete widget.navigate_item_inactive_value;
+                    delete widget.navigate_active_state;
                     break;
 
                 default:
@@ -200,10 +210,20 @@
                     delete widget.navigate_dashboard;
                     delete widget.navigate_type;
                     delete widget.navigate_target;
-                    delete widget.navigate_item_active_value;
-                    delete widget.navigate_item_inactive_value;
+                    delete widget.navigate_active_state;
                     delete widget.action_type;
                     break;
+            }
+
+            if (!widget.show_item_value) {
+                delete widget.show_item_value;
+                delete widget.value_unit;
+                delete widget.value_font_size;
+                delete widget.value_format;
+                delete widget.value_useserverformat;
+                delete widget.value_nolinebreak;
+                delete widget.value_color;
+                delete widget.value_color_active;
             }
 
             $modalInstance.close(widget);

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -37,8 +37,8 @@
             element[0].parentElement.parentElement.className += " activefeedback";
         }
     }
-    ButtonController.$inject = ['$rootScope', '$scope', '$location', 'OHService'];
-    function ButtonController($rootScope, $scope, $location, OHService) {
+    ButtonController.$inject = ['$rootScope', '$scope', '$location', 'OHService', '$window'];
+    function ButtonController($rootScope, $scope, $location, OHService, $window) {
         var vm = this;
         this.widget = this.ngModel;
 
@@ -57,6 +57,35 @@
             }
         }
 
+        function onNavigate() {
+            if (!vm.widget.navigate_url)
+                return;
+
+            if (vm.widget.navigate_type === 'dashboard') {
+                $location.url('/view/' + vm.widget.navigate_url);
+                return;
+            }
+
+            switch (vm.widget.navigate_target || 'self') {
+                case 'new_tab':
+                    var w = $window.open(vm.widget.navigate_url);
+                    w && (w.opener = null);
+                    break;
+
+                case 'new_window':
+                    var w = $window.open(vm.widget.navigate_url, "_blank", "resizable=1", true);
+                    w && (w.opener = null);
+                    break;
+
+                default:
+                case 'self': {
+                    $window.location.href = vm.widget.navigate_url;
+                    break;
+                }
+            }
+
+        }
+
         OHService.onUpdate($scope, vm.widget.item, function () {
             updateValue();
         });
@@ -64,10 +93,9 @@
         vm.sendCommand = function () {
             switch (vm.widget.action_type) {
                 case "navigate":
-                    if (vm.widget.navigate_dashboard) {
-                        $location.url('/view/' + vm.widget.navigate_dashboard);
-                    }
+                    onNavigate();
                     break;
+
                 case "toggle":
                     if (vm.widget.command && vm.widget.command_alt) {
                         if (vm.value === vm.widget.command) {
@@ -103,7 +131,6 @@
             action_type: widget.action_type || 'command',
             command: widget.command,
             command_alt: widget.command_alt,
-            navigate_dashboard: widget.navigate_dashboard,
             background: widget.background,
             foreground: widget.foreground,
             font_size: widget.font_size,
@@ -116,7 +143,11 @@
             icon: widget.icon,
             icon_size: widget.icon_size,
             icon_nolinebreak: widget.icon_nolinebreak,
-            icon_replacestext: widget.icon_replacestext
+            icon_replacestext: widget.icon_replacestext,
+            show_item_value: widget.show_item_value || false,
+            navigate_type: widget.navigate_type || 'dashboard',
+            navigate_url: widget.navigate_url,
+            navigate_target: widget.navigate_target || 'self'
         };
 
         $scope.dismiss = function () {
@@ -132,16 +163,19 @@
             angular.extend(widget, $scope.form);
             switch (widget.action_type) {
                 case "navigate":
-                    delete widget.item;
                     delete widget.command;
                     delete widget.command_alt;
                     break;
                 case "toggle":
-                    delete widget.navigate_dashboard;
+                    delete widget.navigate_url;
+                    delete widget.navigate_type;
+                    delete widget.navigate_target;
                     break;
                 default:
                     delete widget.command_alt;
-                    delete widget.navigate_dashboard;
+                    delete widget.navigate_url;
+                    delete widget.navigate_type;
+                    delete widget.navigate_target;
                     delete widget.action_type;
                     break;
             }

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -58,13 +58,13 @@
         }
 
         function onNavigate() {
-            if (!vm.widget.navigate_url)
-                return;
-
-            if (vm.widget.navigate_type === 'dashboard') {
-                $location.url('/view/' + vm.widget.navigate_url);
+            if (vm.widget.navigate_dashboard) {
+                $location.url('/view/' + vm.widget.navigate_dashboard);
                 return;
             }
+
+            if (!vm.widget.navigate_url)
+                return;
 
             switch (vm.widget.navigate_target || 'self') {
                 case 'new_tab':
@@ -145,9 +145,10 @@
             icon_nolinebreak: widget.icon_nolinebreak,
             icon_replacestext: widget.icon_replacestext,
             show_item_value: widget.show_item_value || false,
-            navigate_type: widget.navigate_type || 'dashboard',
+            navigate_type: (widget.navigate_url) ? 'url' : 'dashboard',
             navigate_url: widget.navigate_url,
-            navigate_target: widget.navigate_target || 'self'
+            navigate_dashboard: widget.navigate_dashboard,
+            navigate_target: widget.navigate_target || 'self',
         };
 
         $scope.dismiss = function () {
@@ -165,15 +166,30 @@
                 case "navigate":
                     delete widget.command;
                     delete widget.command_alt;
+
+                    if ($scope.form.navigate_type === 'dashboard') {
+                        delete widget.navigate_url;
+                        delete widget.navigate_target;
+                    } else {
+                        delete widget.navigate_dashboard;
+                    }
+
+                    if (!$scope.form.show_item_value)
+                        delete widget.item;
+
                     break;
+
                 case "toggle":
                     delete widget.navigate_url;
+                    delete widget.navigate_dashboard;
                     delete widget.navigate_type;
                     delete widget.navigate_target;
                     break;
+
                 default:
                     delete widget.command_alt;
                     delete widget.navigate_url;
+                    delete widget.navigate_dashboard;
                     delete widget.navigate_type;
                     delete widget.navigate_target;
                     delete widget.action_type;

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -192,6 +192,10 @@
                     if (!$scope.form.show_item_value) {
                         delete widget.item;
                         delete widget.navigate_active_state;
+                    } else {
+                        delete widget.background_active;
+                        delete widget.foreground_active;
+                        delete widget.value_color_active;
                     }
 
                     break;

--- a/web/app/widgets/button/button.widget.js
+++ b/web/app/widgets/button/button.widget.js
@@ -48,7 +48,8 @@
 
         function updateValue() {
             vm.value = OHService.getItem(vm.widget.item).state;
-            if (vm.value === vm.widget.command) {
+            if (vm.value === vm.widget.command
+                || (vm.widget.action_type === 'navigate' && vm.widget.show_item_value && vm.value == vm.widget.navigate_item_active_value)) {
                 vm.background = vm.widget.background_active;
                 vm.foreground = vm.widget.foreground_active;
             } else {
@@ -149,6 +150,8 @@
             navigate_url: widget.navigate_url,
             navigate_dashboard: widget.navigate_dashboard,
             navigate_target: widget.navigate_target || 'self',
+            navigate_item_active_value: widget.navigate_item_active_value,
+            navigate_item_inactive_value: widget.navigate_item_inactive_value
         };
 
         $scope.dismiss = function () {
@@ -174,8 +177,11 @@
                         delete widget.navigate_dashboard;
                     }
 
-                    if (!$scope.form.show_item_value)
+                    if (!$scope.form.show_item_value) {
                         delete widget.item;
+                        delete widget.navigate_item_active_value;
+                        delete widget.navigate_item_inactive_value;
+                    }
 
                     break;
 
@@ -184,6 +190,8 @@
                     delete widget.navigate_dashboard;
                     delete widget.navigate_type;
                     delete widget.navigate_target;
+                    delete widget.navigate_item_active_value;
+                    delete widget.navigate_item_inactive_value;
                     break;
 
                 default:
@@ -192,6 +200,8 @@
                     delete widget.navigate_dashboard;
                     delete widget.navigate_type;
                     delete widget.navigate_target;
+                    delete widget.navigate_item_active_value;
+                    delete widget.navigate_item_inactive_value;
                     delete widget.action_type;
                     break;
             }

--- a/web/app/widgets/dummy/dummy.settings.tpl.html
+++ b/web/app/widgets/dummy/dummy.settings.tpl.html
@@ -48,7 +48,7 @@
                 <div class="col-lg-9 col-md-9">
                     <div class="checkbox">
                         <label>
-                            <input type="checkbox" name="vertical" ng-model="form.useserverformat" /> Use server-provided format if available (openHAB 2)
+                            <input type="checkbox" name="vertical" ng-model="form.useserverformat" /> Use server-provided format if available
                         </label>
                     </div>
                 </div>


### PR DESCRIPTION
Previous conversation:
https://github.com/openhab/org.openhab.ui.habpanel/pull/258#issuecomment-354185262

Here's the changes per suggestions:
* Changed "Navigate to dashboard" to "Navigate"
* Change Icons uitab to Display
* Added ability to navigate to an external URL
* Changed ui-select on dashboard select tag
* Use/mimic Dummy widget for Navigate type
* Added ability to show an item value

Basically if you use "Display" on a "Navigate" action type, you can display the Item name/value just like a regular Dummy widget. Same concept as previous PR: ability to navigate to a URL or a dashboard page. Use self/new tab/new window if preferred.

Demo:
![smartbutton](https://user-images.githubusercontent.com/6183345/34427044-5bc2c11c-ebf2-11e7-8005-93d4b63959d2.gif)


I formatted code based on VS Code settings.
You can see actual changes here:
https://github.com/LuckyMallari/org.openhab.ui.habpanel/commit/d56498237fe75cb67c58beb4fdbab494c5e64c21

I also removed huge blocks of code that were not used (commented out)