### PR TITLE
Chart/timeline: Fix date calcs, 2D period, optional serviceId

### DIFF
--- a/web/app/widgets/chart/chart.settings.tpl.html
+++ b/web/app/widgets/chart/chart.settings.tpl.html
@@ -32,9 +32,9 @@
                         </div>
                     </div>
                     <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}" ng-if="form.charttype=='interactive'">
-                        <label class="control-label col-lg-3 col-md-3">Service provider</label>
+                        <label class="control-label col-lg-3 col-md-3">Persistence service</label>
                         <div class="col-lg-9 col-md-9">
-                            <input name="name" type="text" ng-model="form.service" class="form-control" placeholder="rrd4j, mysql, influxdb..." />
+                            <input name="name" type="text" ng-model="form.service" class="form-control" placeholder="rrd4j, mysql, influxdb... Leave blank for default" />
                         </div>
                     </div>
                     <div class="form-group" ng-class="{error: _form.period.$error && _form.submitted}">
@@ -46,6 +46,7 @@
                                 <option value="8h">8h</option>
                                 <option value="12h">12h</option>
                                 <option value="D">D</option>
+                                <option value="2D">2D</option>
                                 <option value="3D">3D</option>
                                 <option value="W">W</option>
                                 <option value="2W">2W</option>

--- a/web/app/widgets/chart/chart.widget.js
+++ b/web/app/widgets/chart/chart.widget.js
@@ -86,13 +86,14 @@
                     case '8h': startDate.setTime(startDate.getTime() - 8*60*60*1000); break;
                     case '12h': startDate.setTime(startDate.getTime() - 12*60*60*1000); break;
                     case 'D': startDate.setTime(startDate.getTime() - 24*60*60*1000); break;
+                    case '2D': startDate.setTime(startDate.getTime() - 2*24*60*60*1000); break;
                     case '3D': startDate.setTime(startDate.getTime() - 3*24*60*60*1000); break;
                     case 'W': startDate.setTime(startDate.getTime() - 7*24*60*60*1000); break;
                     case '2W': startDate.setTime(startDate.getTime() - 2*7*24*60*60*1000); break;
-                    case 'M': startDate.setTime(startDate.getTime() - 31*24*60*60*1000); break; //Well...
-                    case '2M': startDate.setTime(startDate.getTime() - 2*31*24*60*60*1000); break;
-                    case '4M': startDate.setTime(startDate.getTime() - 4*31*24*60*60*1000); break;
-                    case 'Y': startDate.setTime(startDate.getTime() - 12*31*24*60*60*1000); break;
+                    case 'M': startDate.setMonth(startDate.getMonth() - 1); break;
+                    case '2M': startDate.setMonth(startDate.getMonth() - 2); break;
+                    case '4M': startDate.setMonth(startDate.getMonth() - 4); break;
+                    case 'Y': startDate.setFullYear(startDate.getFullYear() - 1); break;
                     default: startDate.setTime(startDate.getTime() - 24*60*60*1000); break;
                 }
                 return startDate;
@@ -106,7 +107,7 @@
 
                 vm.rawdata = [];
                 for (var i = 0; i < vm.widget.series.length; i++) {
-                    vm.rawdata[i] = $http.get('/rest/persistence/items/' + vm.widget.series[i].item + '?serviceId=' + vm.widget.service + "&starttime=" + startDate.toISOString());
+                    vm.rawdata[i] = $http.get('/rest/persistence/items/' + vm.widget.series[i].item + "?starttime=" + startDate.toISOString() + (vm.widget.service ? '&serviceId=' + vm.widget.service : ''));
                 }
 
                 $q.all(vm.rawdata).then(function (values) {

--- a/web/app/widgets/timeline/timeline.settings.tpl.html
+++ b/web/app/widgets/timeline/timeline.settings.tpl.html
@@ -18,9 +18,9 @@
                         </div>
                     </div>
                     <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
-                        <label class="control-label col-lg-3 col-md-3">Service provider</label>
+                        <label class="control-label col-lg-3 col-md-3">Persistence service</label>
                         <div class="col-lg-9 col-md-9">
-                            <input name="name" type="text" ng-model="form.service" class="form-control" placeholder="rrd4j, mysql, influxdb..." />
+                            <input name="name" type="text" ng-model="form.service" class="form-control" placeholder="rrd4j, mysql, influxdb... Leave blank for default" />
                         </div>
                     </div>
                     <div class="form-group" ng-class="{error: _form.period.$error && _form.submitted}">
@@ -32,6 +32,7 @@
                                 <option value="8h">8h</option>
                                 <option value="12h">12h</option>
                                 <option value="D">D</option>
+                                <option value="2D">2D</option>
                                 <option value="3D">3D</option>
                                 <option value="W">W</option>
                                 <option value="2W">2W</option>

--- a/web/app/widgets/timeline/timeline.widget.js
+++ b/web/app/widgets/timeline/timeline.widget.js
@@ -169,13 +169,14 @@
                 case '8h': startDate.setTime(startDate.getTime() - 8*60*60*1000); break;
                 case '12h': startDate.setTime(startDate.getTime() - 12*60*60*1000); break;
                 case 'D': startDate.setTime(startDate.getTime() - 24*60*60*1000); break;
+                case '2D': startDate.setTime(startDate.getTime() - 2*24*60*60*1000); break;
                 case '3D': startDate.setTime(startDate.getTime() - 3*24*60*60*1000); break;
                 case 'W': startDate.setTime(startDate.getTime() - 7*24*60*60*1000); break;
                 case '2W': startDate.setTime(startDate.getTime() - 2*7*24*60*60*1000); break;
-                case 'M': startDate.setTime(startDate.getTime() - 31*24*60*60*1000); break; //Well...
-                case '2M': startDate.setTime(startDate.getTime() - 2*31*24*60*60*1000); break;
-                case '4M': startDate.setTime(startDate.getTime() - 4*31*24*60*60*1000); break;
-                case 'Y': startDate.setTime(startDate.getTime() - 12*31*24*60*60*1000); break;
+                case 'M': startDate.setMonth(startDate.getMonth() - 1); break;
+                case '2M': startDate.setMonth(startDate.getMonth() - 2); break;
+                case '4M': startDate.setMonth(startDate.getMonth() - 4); break;
+                case 'Y': startDate.setFullYear(startDate.getFullYear() - 1); break;
                 default: startDate.setTime(startDate.getTime() - 24*60*60*1000); break;
             }
             return startDate;
@@ -195,7 +196,7 @@
 
             vm.rawdata = [];
             for (var i = 0; i < vm.widget.series.length; i++) {
-                vm.rawdata[i] = $http.get('/rest/persistence/items/' + vm.widget.series[i].item + '?serviceId=' + vm.widget.service + "&boundary=true&starttime=" + startDate.toISOString());
+                vm.rawdata[i] = $http.get('/rest/persistence/items/' + vm.widget.series[i].item + "?boundary=true&starttime=" + startDate.toISOString() + (vm.widget.service ? '&serviceId=' + vm.widget.service : ''));
             }
 
 


### PR DESCRIPTION
- Accurate calculations of start date for M, 2M, 4M, Y periods (fix #265)
- Add missing 2D period
- Omit serviceId parameter for persistence service if blank (use default)

Signed-off-by: Yannick Schaus <habpanel@schaus.net>