### PR TITLE
Fix NaN display when dimmer issued ON/OFF command

### DIFF
--- a/web/app/widgets/slider/slider.widget.js
+++ b/web/app/widgets/slider/slider.widget.js
@@ -54,7 +54,16 @@
                 // slider received HSB value, use the 3rd (brightness)
                 value = parseFloat(parts[2]);
             } else if (parts.length == 1) {
-                value = parseFloat(parts[0]);
+                 var state = parts[0];
+                
+                // Handle dimmer-as-switch case for strings, avoids NaN when ON/OFF sent to dimmers
+                if (state == "ON"){
+                    value = 100;
+                } else if (state == "OFF"){
+                    value = 0;
+                } else {
+                    value = parseFloat(state);
+                }
             } else {
                 return undefined;
             }


### PR DESCRIPTION
The value of a slider/dimmer item is naively assumed to be numerical. Many OpenHAB dimmer components are issued ON/OFF commands instead of 0/100. This causes the slider widget to display NaN as the item value, and causes visual artifacts as well (value below the floor).

Add a check for ON/OFF strings, before assuming value is numerical and parsing it as a float.