### PR TITLE
Allow formatting of UoM item states

### DIFF
--- a/web/app/widgets/chart/chart.widget.js
+++ b/web/app/widgets/chart/chart.widget.js
@@ -55,10 +55,20 @@
         function formatValue(itemname, val) {
             var item = OHService.getItem(itemname);
                 
-            if (item && item.stateDescription && item.stateDescription.pattern)
-                return sprintf(item.stateDescription.pattern, val);
-            else
-                return val;
+            if (item && item.stateDescription && item.stateDescription.pattern) {
+                if (item.type.indexOf('Number:') === 0 && item.state.indexOf(' ') > 0) {
+                    var format = item.stateDescription.pattern.replace('%unit%', item.state.split(' ')[1].replace('%', '%%'));
+                    return sprintf(format, val);
+                } else {
+                    return sprintf(item.stateDescription.pattern, val);
+                }
+            } else {
+                if (item.type.indexOf('Number:') === 0 && item.state.indexOf(' ') > 0) {
+                    return val + ' ' + item.state.split(' ')[1];
+                } else {
+                    return val;
+                }
+            }
         }
 
         function tooltipHook(values) {

--- a/web/app/widgets/dummy/dummy.widget.js
+++ b/web/app/widgets/dummy/dummy.widget.js
@@ -51,12 +51,21 @@
             if (vm.widget.format) {
                 if (item.type === "DateTime" || item.type === "DateTimeItem") {
                     value = $filter('date')(value, vm.widget.format);
+                } else if (item.type.indexOf('Number:') === 0 && value.indexOf(' ') > 0) {
+                    var format = vm.widget.format.replace('%unit%', value.split(' ')[1].replace('%', '%%'));
+                    value = sprintf(format, value.split(' ')[0]);
                 } else {
                     value = sprintf(vm.widget.format, value);
                 }
             }
-            if (vm.widget.useserverformat && item.stateDescription && item.stateDescription.pattern)
-                value = sprintf(item.stateDescription.pattern, value);
+            if (vm.widget.useserverformat && item.stateDescription && item.stateDescription.pattern) {
+                if (item.type.indexOf('Number:') === 0 && value.indexOf(' ') > 0) {
+                    var format = item.stateDescription.pattern.replace('%unit%', value.split(' ')[1].replace('%', '%%'));
+                    value = sprintf(format, value.split(' ')[0]);
+                } else {
+                    value = sprintf(item.stateDescription.pattern, value);
+                }
+            }
             vm.value = value;
             vm.state = item.state;
         }

--- a/web/app/widgets/knob/knob.widget.js
+++ b/web/app/widgets/knob/knob.widget.js
@@ -33,7 +33,6 @@
         };
         return directive;
 
-        
         function link(scope, element, attrs) {
 
             function computeSize() {
@@ -77,7 +76,7 @@
 
             if (vm.widget.useserverformat && item.stateDescription && item.stateDescription.pattern) {
                 vm.knob.options.inputFormatter = function (input) {
-                    return sprintf(item.stateDescription.pattern, input);
+                    return sprintf(item.stateDescription.pattern.replace('%unit%', ''), input);
                 }
             }
 

--- a/web/app/widgets/widgets.module.js
+++ b/web/app/widgets/widgets.module.js
@@ -105,8 +105,8 @@
             link: link,
             restrict: 'AE',
             template:
-                '<strong ng-if="type === \'Number\'" title="Number" style="font-size: 1.2em; line-height: 0.9em; margin: -0.2em 0.1em;">#</strong>' +
-                '<i ng-if="type !== \'Number\'" title="{{type}}" class="glyphicon glyphicon-{{getGlyph()}}"></i>',
+                '<strong ng-if="type.indexOf(\'Number\') >= 0" title="Number" style="font-size: 1.2em; line-height: 0.9em; margin: -0.2em 0.1em;">#</strong>' +
+                '<i ng-if="type.indexOf(\'Number\') < 0" title="{{type}}" class="glyphicon glyphicon-{{getGlyph()}}"></i>',
             scope: {
                 type: '='
             }


### PR DESCRIPTION
Allow formats defined in widgets and item's state descriptions
to work with items having an Unit of Measurement specified.

Also supports the %unit% placeholder in formats whenever applicable.
(note: the Knob widget removes the unit, which must be configured
explicitely).

Fixes #309.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>