### PR TITLE
Pass unused OpenHAB events on for other components to use.

### DIFF
--- a/web/app/services/openhab.service.js
+++ b/web/app/services/openhab.service.js
@@ -250,6 +250,13 @@
                                 if (context)
                                   context.close();
                             }
+                        } else {
+                            var payload = JSON.parse(evtdata.payload);
+                            var ohEvent = { topic: evtdata.topic, type: evtdata.type, payload: payload };
+                            $rootScope.$apply(function () {
+                                console.log("Emitting event type=" + ohEvent.type + ", topic=" + ohEvent.topic);
+                                $rootScope.$emit('openhab-event', ohEvent);
+                            });
                         }
                     } catch (e) {
                         console.warn('SSE event issue: ' + e.message);


### PR DESCRIPTION
OpenHAB permits custom event types to be defined. These events are passed to HABPanel but are silently dropped. By passing on unused events, downstream components such as Widgets can make use of the data.

Note: This PR emits the events onto a new "topic" in $rootScope. The thinking is that by emitting rather than broadcasting, some noise can be avoided by child scopes (and most uses can get $rootScope by using DI). 

Fixes #314.

Signed-off-by: William Welliver <william@welliver.org> (github: hww3)
