### PR TITLE
Don't forward smarthome events to rootScope

### DIFF
--- a/web/app/services/openhab.service.js
+++ b/web/app/services/openhab.service.js
@@ -250,7 +250,7 @@
                                 if (context)
                                   context.close();
                             }
-                        } else {
+                        } else if (topicparts[0] !== 'smarthome') {
                             var payload = JSON.parse(evtdata.payload);
                             var ohEvent = { topic: evtdata.topic, type: evtdata.type, payload: payload };
                             $rootScope.$apply(function () {


### PR DESCRIPTION
Only allow custom events (i.e. those whose topic doesn't start
with "smarthome") to be emitted on the root scope.
This prevents flooding and a potential performance hit for users
who don't need this feature.

Related to #315.

Signed-off-by: Yannick Schaus <habpanel@schaus.net>