### PR TITLE
Fixed display of selected choice in selection widget

### DIFF
--- a/web/app/widgets/selection/selection.widget.js
+++ b/web/app/widgets/selection/selection.widget.js
@@ -71,8 +71,12 @@
                 }
             }
 
-            if ($filter('filter')(vm.choices, { cmd: vm.state }).length > 0) {
-                vm.currentChoice = $filter('filter')(vm.choices, { cmd: vm.state })[0];
+            function filterChoice(choice, i, choices) {
+                if (choice.cmd === vm.state) return true;
+                return false;
+            }
+            if ($filter('filter')(vm.choices, filterChoice).length > 0) {
+                vm.currentChoice = $filter('filter')(vm.choices, filterChoice)[0];
                 if (vm.currentChoice.label)
                     vm.value = vm.currentChoice.label;
             }


### PR DESCRIPTION
When the filter function is used with an object expression, it returns all objects whose properties CONTAIN the value of the given object, and not which EQUAL the value, see [0]. So if you e.g. have 3 choices with 15, 1 and 31 as "cmd" property, a "{cmd: 1}" expression returns all 3 objects, and not only the object which actually has "cmd: 1", and the wrong object with "cmd: 15" is displayed because it'the first one.
With this fix a function expression is used for the filter, which finds the choice with the exact matching "cmd" property.

[0] https://docs.angularjs.org/api/ng/filter/filter