### PR TITLE
Fix #339 - fullscreen broken in Chrome 71+

### DIFF
--- a/web/app/dashboard/dashboard.view.controller.js
+++ b/web/app/dashboard/dashboard.view.controller.js
@@ -66,6 +66,9 @@
     };
 
     vm.goFullscreen = function() {
+        // fix for Chrome 71+ fullscreen
+        Element.prototype.webkitRequestFullscreen = function () { this.requestFullscreen(); }
+
         Fullscreen.toggleAll();
     };
 


### PR DESCRIPTION
Signed-off-by: Yannick Schaus <habpanel@schaus.net>